### PR TITLE
Add `verify_with_schema_check` function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "lib",
     "generate_keys",
     "vc_signer",
-    "wasm"
+    "wasm",
+    "release"
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,7 +2061,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verifiable-credential-toolkit"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verifiable-credential-toolkit"
-version = "0.4.0"
+version = "0.5.0"
 description = "Provides methods for handling, constructing and signing Verifiable Credentials"
 authors = ["Henry Pearson <henry@nquiringminds.com>"]
 edition = "2021"

--- a/src/bin/vc_signer.rs
+++ b/src/bin/vc_signer.rs
@@ -82,7 +82,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Sign the VC based on schema validation options
             let signed_vc = if let Some(schema_path) = schema {
                 let schema_str = fs::read_to_string(schema_path)?;
-                unsigned_vc.sign_with_schema_check(&private_key, &schema_str)?
+                let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
+                unsigned_vc.sign_with_schema_check(&private_key, &schema_json)?
             } else {
                 #[cfg(not(target_arch = "wasm32"))]
                 if let Some(url) = schema_url {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,14 +294,12 @@ impl UnsignedVerifiableCredential {
     pub fn sign_with_schema_check(
         self,
         private_key: impl AsRef<[u8]>,
-        schema: &str,
+        schema: &Value,
     ) -> Result<VerifiableCredential, Box<dyn std::error::Error>> {
         // Validate the credentialSubject against the provided schema
-        let schema: Value =
-            serde_json::from_str(schema).map_err(|e| format!("Failed to parse schema: {}", e))?;
         let credential_subject = &self.credential_subject;
 
-        if !jsonschema::is_valid(&schema, credential_subject) {
+        if !jsonschema::is_valid(schema, credential_subject) {
             return Err("Credential subject does not match schema".into());
         }
 
@@ -450,14 +448,12 @@ impl VerifiableCredential {
     pub fn verify_with_schema_check(
         &self,
         public_key: &[u8],
-        schema: &str,
+        schema: &Value,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // Validate the credentialSubject against the provided schema
-        let schema: Value =
-            serde_json::from_str(schema).map_err(|e| format!("Failed to parse schema: {}", e))?;
         let credential_subject = &self.unsigned.credential_subject;
 
-        if !jsonschema::is_valid(&schema, credential_subject) {
+        if !jsonschema::is_valid(schema, credential_subject) {
             return Err("Credential subject does not match schema".into());
         }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -124,7 +124,6 @@ pub fn verify(signed_vc: JsValue, public_key: &[u8]) -> Result<bool, JsError> {
         Err(_e) => Ok(false),
     }
 }
-
 #[wasm_bindgen]
 pub fn verify_with_schema_check(
     signed_vc: JsValue,
@@ -138,10 +137,9 @@ pub fn verify_with_schema_check(
         ))
     })?;
 
-    let schema_str = serde_wasm_bindgen::from_value::<serde_json::Value>(schema)
-        .map_err(|_| JsError::new("Failed to deserialize schema"))?
-        .to_string();
-    match vc.verify_with_schema_check(public_key, &schema_str) {
+    let schema_value = serde_wasm_bindgen::from_value::<serde_json::Value>(schema)
+        .map_err(|_| JsError::new("Failed to deserialize schema"))?;
+    match vc.verify_with_schema_check(public_key, &schema_value) {
         Ok(_) => Ok(true),
         Err(_e) => Ok(false),
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -126,6 +126,28 @@ pub fn verify(signed_vc: JsValue, public_key: &[u8]) -> Result<bool, JsError> {
 }
 
 #[wasm_bindgen]
+pub fn verify_with_schema_check(
+    signed_vc: JsValue,
+    public_key: &[u8],
+    schema: JsValue,
+) -> Result<bool, JsError> {
+    let vc: VerifiableCredential = from_value(signed_vc).map_err(|e| {
+        JsError::new(&format!(
+            "Failed to deserialize signed verifiable credential: {}",
+            e
+        ))
+    })?;
+
+    let schema_str = serde_wasm_bindgen::from_value::<serde_json::Value>(schema)
+        .map_err(|_| JsError::new("Failed to deserialize schema"))?
+        .to_string();
+    match vc.verify_with_schema_check(public_key, &schema_str) {
+        Ok(_) => Ok(true),
+        Err(_e) => Ok(false),
+    }
+}
+
+#[wasm_bindgen]
 pub struct KeyPair {
     signing_key: Vec<u8>,
     verifying_key: Vec<u8>,

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -92,10 +92,12 @@ mod tests {
         let private_key: &[u8] = &std::fs::read("tests/test_data/keys/key.priv")
             .expect("Error reading private key from file");
 
-        let schema = include_str!("test_data/schemas/schema.json");
+        let schema_str = include_str!("test_data/schemas/schema.json");
+        let schema: serde_json::Value =
+            serde_json::from_str(schema_str).expect("Failed to parse schema JSON");
 
         let signed_vc = vc
-            .sign_with_schema_check(private_key, schema)
+            .sign_with_schema_check(private_key, &schema)
             .expect("Failed to sign VC");
 
         assert!(serde_json::to_string(&signed_vc).is_ok());
@@ -111,9 +113,11 @@ mod tests {
         let private_key: &[u8] = &std::fs::read("tests/test_data/keys/key.priv")
             .expect("Error reading private key from file");
 
-        let schema = include_str!("test_data/schemas/schema_fail.json");
+        let schema_str = include_str!("test_data/schemas/schema_fail.json");
+        let schema: serde_json::Value =
+            serde_json::from_str(schema_str).expect("Failed to parse schema JSON");
 
-        let signed_vc = vc.sign_with_schema_check(private_key, schema);
+        let signed_vc = vc.sign_with_schema_check(private_key, &schema);
 
         assert!(signed_vc.is_err());
     }
@@ -414,9 +418,11 @@ mod tests {
         .sign(private_key)
         .expect("Failed to sign VC");
 
-        let schema = include_str!("test_data/schemas/schema.json");
+        let schema_str = include_str!("test_data/schemas/schema.json");
+        let schema: serde_json::Value =
+            serde_json::from_str(schema_str).expect("Failed to parse schema JSON");
 
-        let verify_result = vc.verify_with_schema_check(&public_key, schema);
+        let verify_result = vc.verify_with_schema_check(&public_key, &schema);
 
         assert!(verify_result.is_ok());
     }
@@ -435,9 +441,11 @@ mod tests {
         .sign(private_key)
         .expect("Failed to sign VC");
 
-        let schema = include_str!("test_data/schemas/schema_fail.json");
+        let schema_str = include_str!("test_data/schemas/schema_fail.json");
+        let schema: serde_json::Value =
+            serde_json::from_str(schema_str).expect("Failed to parse schema JSON");
 
-        let verify_result = vc.verify_with_schema_check(&public_key, schema);
+        let verify_result = vc.verify_with_schema_check(&public_key, &schema);
 
         assert!(verify_result.is_err());
     }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -399,4 +399,46 @@ mod tests {
 
         assert!(verify_result.is_ok());
     }
+
+    #[test]
+    fn validate_with_schema_check_true_positive() {
+        let private_key: &[u8] = &std::fs::read("tests/test_data/keys/key.priv")
+            .expect("Error reading private key from file");
+        let public_key = std::fs::read("tests/test_data/keys/key.pub")
+            .expect("Error reading public key from file");
+
+        let vc: VerifiableCredential = serde_json::from_str::<UnsignedVerifiableCredential>(
+            include_str!("test_data/verifiable_credentials/unsigned.json"),
+        )
+        .expect("Failed to deserialize JSON")
+        .sign(private_key)
+        .expect("Failed to sign VC");
+
+        let schema = include_str!("test_data/schemas/schema.json");
+
+        let verify_result = vc.verify_with_schema_check(&public_key, schema);
+
+        assert!(verify_result.is_ok());
+    }
+
+    #[test]
+    fn validate_with_schema_check_true_negative() {
+        let private_key: &[u8] = &std::fs::read("tests/test_data/keys/key.priv")
+            .expect("Error reading private key from file");
+        let public_key = std::fs::read("tests/test_data/keys/key.pub")
+            .expect("Error reading public key from file");
+
+        let vc: VerifiableCredential = serde_json::from_str::<UnsignedVerifiableCredential>(
+            include_str!("test_data/verifiable_credentials/unsigned.json"),
+        )
+        .expect("Failed to deserialize JSON")
+        .sign(private_key)
+        .expect("Failed to sign VC");
+
+        let schema = include_str!("test_data/schemas/schema_fail.json");
+
+        let verify_result = vc.verify_with_schema_check(&public_key, schema);
+
+        assert!(verify_result.is_err());
+    }
 }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -89,10 +89,12 @@ mod wasm_tests {
 
         let private_key: &[u8] = include_bytes!("test_data/keys/key.priv");
 
-        let schema = include_str!("test_data/schemas/schema.json");
+        let schema_str = include_str!("test_data/schemas/schema.json");
+        let schema: serde_json::Value =
+            serde_json::from_str(schema_str).expect("Failed to parse schema JSON");
 
         let signed_vc = vc
-            .sign_with_schema_check(private_key, schema)
+            .sign_with_schema_check(private_key, &schema)
             .expect("Failed to sign VC");
 
         assert!(serde_json::to_string(&signed_vc).is_ok());
@@ -107,9 +109,11 @@ mod wasm_tests {
 
         let private_key: &[u8] = include_bytes!("test_data/keys/key.priv");
 
-        let schema = include_str!("test_data/schemas/schema_fail.json");
+        let schema_str = include_str!("test_data/schemas/schema_fail.json");
+        let schema: serde_json::Value =
+            serde_json::from_str(schema_str).expect("Failed to parse schema JSON");
 
-        let signed_vc = vc.sign_with_schema_check(private_key, schema);
+        let signed_vc = vc.sign_with_schema_check(private_key, &schema);
 
         assert!(signed_vc.is_err());
     }

--- a/wasm_nodejs_example_usage/index.js
+++ b/wasm_nodejs_example_usage/index.js
@@ -1,30 +1,56 @@
 // index.js
-import { sign, verify } from "./pkg/verifiable_credential_toolkit.js";
+import {
+  sign,
+  verify,
+  verify_with_schema_check,
+} from "./pkg/verifiable_credential_toolkit.js";
 
 async function run() {
   // Example Unsigned Verifiable Credential (VC)
   const unsignedVC = {
-    "@context": ["https://www.w3.org/2018/credentials/v1"],
-    "id": "http://example.com/credentials/3732",
-    "type": ["VerifiableCredential"],
-    "issuer": "https://example.com/issuers/14",
-    "credentialSubject": { "id": "did:example:abcdef" }
+    "@context": ["https://www.w3.org/ns/credentials/v2"],
+    id: "urn:uuid:9a3e3c0e-2db0-412a-95c7-cf5520ba78df",
+    type: ["VerifiableCredential", "ExampleVerifiableCredential"],
+    issuer: "https://www.example.com/",
+    validFrom: "2024-08-22T13:53:32.295644150Z",
+    credentialSchema: {
+      id: "https://www.example.com/foo.json",
+      type: "JsonSchema",
+    },
+    credentialSubject: {
+      name: "HenryTrustPhone",
+      id: "HenryTrustPhone-id",
+    },
+  };
+
+  const schema = {
+    description: "A device",
+    properties: {
+      id: {
+        description: "id of the device",
+        type: "string",
+      },
+      name: {
+        description: "user friendly name of the device",
+        type: "string",
+      },
+    },
+    required: ["id"],
+    title: "device",
+    type: "object",
   };
 
   // Dummy private key (32 bytes) for testing.
   const privateKeyArray = new Uint8Array([
-    249, 36, 149, 249, 249, 117, 133, 209,
-    234, 131, 132, 144, 15, 129, 114, 114,
-    244, 234, 241, 239, 198, 73, 72, 185,
-    156, 200, 237, 170, 2, 142, 41, 36
+    249, 36, 149, 249, 249, 117, 133, 209, 234, 131, 132, 144, 15, 129, 114,
+    114, 244, 234, 241, 239, 198, 73, 72, 185, 156, 200, 237, 170, 2, 142, 41,
+    36,
   ]);
 
   // Dummy public key (32 bytes) for testing.
   const publicKeyArray = new Uint8Array([
-    158, 252, 71, 183, 71, 40, 45, 125,
-    208, 153, 210, 175, 216, 211, 29, 93,
-    55, 89, 128, 135, 108, 220, 209, 142,
-    148, 55, 66, 57, 157, 249, 8, 204
+    158, 252, 71, 183, 71, 40, 45, 125, 208, 153, 210, 175, 216, 211, 29, 93,
+    55, 89, 128, 135, 108, 220, 209, 142, 148, 55, 66, 57, 157, 249, 8, 204,
   ]);
 
   try {
@@ -33,7 +59,11 @@ async function run() {
     console.log("Signed VC:", signedVC);
 
     // Verify the signed VC
-    const verificationResult = verify(signedVC, publicKeyArray);
+    const verificationResult = verify_with_schema_check(
+      signedVC,
+      publicKeyArray,
+      schema
+    );
     console.log("Verification result:", verificationResult);
   } catch (err) {
     console.error("Error during signing or verifying:", err);


### PR DESCRIPTION
Note: this takes a JSON schema, not a verifiable credential of a schema. So if you have a schema in a VC, make sure to pass the `credentialSubject`.

Closes #28 