### PR TITLE
add key to registry

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Publish to npm
         working-directory: pkg
-        run: npm publish --access public
+        run: |
+          npm set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The workflow publishes fine when tested locally with the same token I'm trying to  explicitly write the token into npm's config, hopefully will fix the remote as well ..

Hopefully it works :crossed_fingers: 