### PR TITLE
47 issues to be tackled for adding ml dsa support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,16 @@
 # stack (~1 MB) overflows during key expansion/signing, surfacing as a wasm "memory access
 # out of bounds" trap. Raise the wasm stack to 8 MB so ML-DSA runs in the browser/Node.
 #
-# Note: this applies when building *this* crate to wasm (including `wasm-pack build/test`).
-# Downstream crates compiling this to wasm themselves need the same flag in their own config.
+# Hedged ML-DSA signing draws randomness via getrandom 0.4, whose wasm backend must be
+# selected explicitly with `getrandom_backend="wasm_js"` (in addition to the wasm_js
+# feature) to work at runtime in the browser/Node.
+#
+# Note: these apply when building *this* crate to wasm (including `wasm-pack build/test`).
+# Downstream crates compiling this to wasm themselves need the same flags in their own config.
 [target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-zstack-size=8388608"]
+rustflags = [
+    "-C",
+    "link-arg=-zstack-size=8388608",
+    "--cfg",
+    'getrandom_backend="wasm_js"',
+]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,8 @@
 # ML-DSA (FIPS 204) expands large matrices of polynomials on the stack. The default wasm
 # stack (~1 MB) overflows during key expansion/signing, surfacing as a wasm "memory access
-# out of bounds" trap. Raise the wasm stack to 8 MB so ML-DSA runs in the browser/Node.
+# out of bounds" trap. Raise the wasm stack to 16 MB so ML-DSA runs in the browser/Node.
+# Debug builds (e.g. `wasm-pack test --node` without `--release`) use much deeper frames, so
+# the extra headroom matters there; release builds need only a fraction of this.
 #
 # Hedged ML-DSA signing draws randomness via getrandom 0.4, whose wasm backend must be
 # selected explicitly with `getrandom_backend="wasm_js"` (in addition to the wasm_js
@@ -11,7 +13,7 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
     "-C",
-    "link-arg=-zstack-size=8388608",
+    "link-arg=-zstack-size=16777216",
     "--cfg",
     'getrandom_backend="wasm_js"',
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+# ML-DSA (FIPS 204) expands large matrices of polynomials on the stack. The default wasm
+# stack (~1 MB) overflows during key expansion/signing, surfacing as a wasm "memory access
+# out of bounds" trap. Raise the wasm stack to 8 MB so ML-DSA runs in the browser/Node.
+#
+# Note: this applies when building *this* crate to wasm (including `wasm-pack build/test`).
+# Downstream crates compiling this to wasm themselves need the same flag in their own config.
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "link-arg=-zstack-size=8388608"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test --all-features
-      - run: wasm-pack test --node
+      # Release: debug ML-DSA on wasm uses very deep stack frames and overflows even the
+      # raised wasm stack (a "memory access out of bounds" trap); release keeps stack usage
+      # well within it. Native debug coverage already comes from `cargo test` above.
+      - run: wasm-pack test --node --release
       # Run the Rust examples so they can't drift silently. post_quantum self-checks via
       # `?`; all three fail the job on a panic or non-zero exit.
       - run: cargo run --example full_workflow

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,10 +11,11 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      # After the toolchain is set up: the wasm-pack installer needs rustup to exist.
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: cargo test --all-features
       # Release: debug ML-DSA on wasm uses very deep stack frames and overflows even the
       # raised wasm stack (a "memory access out of bounds" trap); release keeps stack usage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,39 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test --all-features
       - run: wasm-pack test --node
+      # Run the Rust examples so they can't drift silently. post_quantum self-checks via
+      # `?`; all three fail the job on a panic or non-zero exit.
+      - run: cargo run --example full_workflow
+      - run: cargo run --example schema_validation
+      - run: cargo run --example post_quantum
+
+  # Build and run the WASM JS examples so the JS ABI and example code stay in sync with the
+  # Rust API. The Node example is a self-checking smoke test (exits non-zero on failure); the
+  # browser example's build runs tsc, so it guards the browser example against type drift.
+  wasm-examples:
+    name: wasm examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      # wasm-bindgen-cli must match the wasm-bindgen version in Cargo.toml.
+      - run: cargo install wasm-bindgen-cli --version 0.2.100
+      - name: Node example (self-checking smoke test, exercises Ed25519 + ML-DSA)
+        working-directory: wasm_nodejs_example_usage
+        run: |
+          npm install
+          npm run build
+          node index.ts
+      - name: Browser example (build + tsc typecheck)
+        working-directory: wasm_js_example_usage
+        run: |
+          npm install
+          npm run build
 
   # Check formatting with rustfmt
   formatting:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,12 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,7 +568,6 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -1577,15 +1570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy 0.7.35",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,27 +1718,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
 
 [[package]]
 name = "rand_core"
@@ -2567,7 +2530,6 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 name = "verifiable-credential-toolkit"
 version = "0.6.0"
 dependencies = [
- "base64",
  "c2pa_cbor",
  "chrono",
  "clap",
@@ -2582,7 +2544,6 @@ dependencies = [
  "protobuf-codegen",
  "protobuf-json-mapping",
  "protoc-bin-vendored",
- "rand",
  "reqwest",
  "serde",
  "serde-wasm-bindgen",
@@ -2955,7 +2916,6 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
  "zerocopy-derive 0.7.35",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +308,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -329,6 +341,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,15 +366,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -412,7 +453,17 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -433,7 +484,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "crypto-common",
+ "crypto-common 0.1.6",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -453,9 +513,9 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "serde",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -466,7 +526,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -673,6 +733,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +854,16 @@ name = "httparse"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "ctutils",
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1096,6 +1180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1259,33 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ml-dsa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "shake",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -1358,8 +1479,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.9",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -1528,6 +1659,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,7 +1672,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1545,7 +1682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1556,6 +1693,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ref-cast"
@@ -1922,8 +2065,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -1938,7 +2092,17 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1973,8 +2137,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.9",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2243,9 +2423,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -2322,8 +2502,10 @@ dependencies = [
  "clap",
  "ed25519-dalek",
  "getrandom 0.2.15",
+ "getrandom 0.4.3",
  "js-sys",
  "jsonschema",
+ "ml-dsa",
  "protobuf",
  "protobuf-codegen",
  "protobuf-json-mapping",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,7 +2528,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verifiable-credential-toolkit"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "c2pa_cbor",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str",
+ "match-lookup",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +332,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +466,32 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+dependencies = [
+ "data-encoding",
  "syn",
 ]
 
@@ -1220,6 +1268,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "match-lookup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1345,18 @@ dependencies = [
  "ctutils",
  "hybrid-array",
  "num-traits",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+dependencies = [
+ "base-x",
+ "base256emoji",
+ "data-encoding",
+ "data-encoding-macro",
 ]
 
 [[package]]
@@ -2506,6 +2577,7 @@ dependencies = [
  "js-sys",
  "jsonschema",
  "ml-dsa",
+ "multibase",
  "protobuf",
  "protobuf-codegen",
  "protobuf-json-mapping",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,11 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.137"
 chrono = { version = "0.4.39", features = ["serde"] }
 serde_with = "3.12.0"
-ed25519-dalek = { version = "2.1.1", features = ["serde", "rand_core"] }
-base64 = "0.22.1"
+ed25519-dalek = { version = "2.1.1", features = ["serde"] }
 jsonschema = { version = "0.28.3", default-features = false }
 reqwest = { version = "0.12.12", features = ["blocking"] }
 url = { version = "2.5.4", features = ["serde"] }
 clap = { version = "4.5.27", features = ["derive"] }
-rand = "0.8"
 wasm-bindgen-test = "0.3.50"
 js-sys = "0.3.77"
 protobuf = "3.7.2"
@@ -40,14 +38,13 @@ getrandom_v04 = { version = "0.4", package = "getrandom", features = ["sys_rng"]
 wasm-bindgen = { version = "0.2", features = ["serde"] }
 serde-wasm-bindgen = "0.6.5"
 reqwest = { version = "0.12.12", features = ["blocking"] }
-# ml-dsa pulls in getrandom 0.4 transitively; enable its wasm backend so the crate
-# still compiles for wasm32 (rand 0.8 uses the separate getrandom 0.2 below).
+# Our own randomness (keygen + hedged signing) goes through getrandom 0.4, so its wasm
+# backend must be enabled.
 getrandom_v04 = { package = "getrandom", version = "0.4", features = ["sys_rng", "wasm_js"] }
-
-
-[dependencies.getrandom]
-version = "0.2.15"
-features = ["js"]
+# getrandom 0.2 is still pulled in transitively (ahash, via jsonschema) and has no default
+# wasm backend; enable its `js` backend so the crate compiles for wasm32. Needed only on
+# wasm — on native this version resolves automatically.
+getrandom = { version = "0.2.15", features = ["js"] }
 
 [build-dependencies]
 protobuf-codegen = "3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verifiable-credential-toolkit"
-version = "0.6.0"
+version = "0.7.0"
 description = "Provides methods for handling, constructing and signing Verifiable Credentials"
 authors = ["Henry Pearson <henry@nquiringminds.com>"]
 edition = "2021"
@@ -23,8 +23,6 @@ jsonschema = { version = "0.28.3", default-features = false }
 reqwest = { version = "0.12.12", features = ["blocking"] }
 url = { version = "2.5.4", features = ["serde"] }
 clap = { version = "4.5.27", features = ["derive"] }
-wasm-bindgen-test = "0.3.50"
-js-sys = "0.3.77"
 protobuf = "3.7.2"
 protobuf-json-mapping = "3.7.2"
 c2pa_cbor = "0.77.2"
@@ -37,6 +35,9 @@ getrandom_v04 = { version = "0.4", package = "getrandom", features = ["sys_rng"]
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen = { version = "0.2", features = ["serde"] }
 serde-wasm-bindgen = "0.6.5"
+# js-sys is used only by src/wasm.rs (the wasm32-only JS ABI), so it is scoped to the
+# wasm target rather than pulled into native builds.
+js-sys = "0.3.77"
 reqwest = { version = "0.12.12", features = ["blocking"] }
 # Our own randomness (keygen + hedged signing) goes through getrandom 0.4, so its wasm
 # backend must be enabled.
@@ -49,3 +50,7 @@ getrandom = { version = "0.2.15", features = ["js"] }
 [build-dependencies]
 protobuf-codegen = "3.7"
 protoc-bin-vendored = "3"
+
+# wasm-bindgen-test is only used by tests/wasm.rs, which compiles for the wasm target.
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+wasm-bindgen-test = "0.3.50"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ serde-wasm-bindgen = "0.6.5"
 # js-sys is used only by src/wasm.rs (the wasm32-only JS ABI), so it is scoped to the
 # wasm target rather than pulled into native builds.
 js-sys = "0.3.77"
-reqwest = { version = "0.12.12", features = ["blocking"] }
 # Our own randomness (keygen + hedged signing) goes through getrandom 0.4, so its wasm
 # backend must be enabled.
 getrandom_v04 = { package = "getrandom", version = "0.4", features = ["sys_rng", "wasm_js"] }
@@ -51,6 +50,9 @@ getrandom = { version = "0.2.15", features = ["js"] }
 protobuf-codegen = "3.7"
 protoc-bin-vendored = "3"
 
-# wasm-bindgen-test is only used by tests/wasm.rs, which compiles for the wasm target.
+# Dev-deps for tests/wasm.rs, which compiles for the wasm target. wasm-bindgen and
+# serde-wasm-bindgen let the tests build/inspect JsValues when exercising the JS ABI.
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = "0.3.50"
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,15 @@ protobuf-json-mapping = "3.7.2"
 c2pa_cbor = "0.77.2"
 thiserror = "2"
 serde_jcs = "0.2.0"
+ml-dsa = "0.1.1"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen = { version = "0.2", features = ["serde"] }
 serde-wasm-bindgen = "0.6.5"
 reqwest = { version = "0.12.12", features = ["blocking"] }
+# ml-dsa pulls in getrandom 0.4 transitively; enable its wasm backend so the crate
+# still compiles for wasm32 (rand 0.8 uses the separate getrandom 0.2 below).
+getrandom_v04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 
 
 [dependencies.getrandom]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ c2pa_cbor = "0.77.2"
 thiserror = "2"
 serde_jcs = "0.2.0"
 ml-dsa = "0.1.1"
+multibase = "0.9.2"
+getrandom_v04 = { version = "0.4", package = "getrandom", features = ["sys_rng"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen = { version = "0.2", features = ["serde"] }
@@ -40,7 +42,7 @@ serde-wasm-bindgen = "0.6.5"
 reqwest = { version = "0.12.12", features = ["blocking"] }
 # ml-dsa pulls in getrandom 0.4 transitively; enable its wasm backend so the crate
 # still compiles for wasm32 (rand 0.8 uses the separate getrandom 0.2 below).
-getrandom_v04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+getrandom_v04 = { package = "getrandom", version = "0.4", features = ["sys_rng", "wasm_js"] }
 
 
 [dependencies.getrandom]

--- a/README.md
+++ b/README.md
@@ -719,14 +719,20 @@ All fallible operations return `Result<_, VcError>` — a typed error enum you c
 
 #### Serialization formats (CBOR / Protobuf)
 
-The `bindings` module abstracts wire formats behind the `CredentialCodec` trait. Each format (`bindings::cbor::Cbor`, `bindings::protobuf::Protobuf`) implements it, and two generic helpers work over any codec:
+The `bindings` module abstracts wire formats behind the `CredentialCodec` trait. Each format (`bindings::cbor::Cbor`, `bindings::protobuf::Protobuf`) implements four bytes↔domain conversions; the sign/verify pipeline is provided once as default methods on the trait, so the format *type* is the entry point — there are no per-format free functions to learn. Because the signature is over the format-independent JCS canonical form, a credential signed in one format verifies in any other.
 
-| Function | Description |
+| Method (on `Cbor` / `Protobuf`) | Description |
 | --- | --- |
-| `bindings::sign_via::<C>(&[u8], &SigningKey) → Result<Vec<u8>>` | Decode unsigned bytes in format `C`, sign, re-encode |
-| `bindings::verify_via::<C>(&[u8], &VerifyingKey) → Result<()>` | Decode signed bytes in format `C` and verify |
+| `C::encode_unsigned(&Unsigned…) → Result<Vec<u8>>` / `C::encode_signed(&…) → Result<Vec<u8>>` | Encode to this format's bytes |
+| `C::decode_unsigned(&[u8])` / `C::decode_signed(&[u8])` | Decode from this format's bytes |
+| `C::sign(&[u8], Algorithm, &[u8]) → Result<Vec<u8>>` | Decode unsigned bytes, sign with any cryptosuite, re-encode |
+| `C::verify(&[u8], Algorithm, &[u8]) → Result<()>` | Decode signed bytes and verify with an explicit algorithm |
+| `C::verify_auto(&[u8], &[u8]) → Result<()>` | Verify, reading the algorithm from the proof's `cryptosuite` |
 
-The per-format convenience wrappers (`sign_cbor_vc`, `verify_cbor_vc`, `sign_protobuf_vc`, `verify_protobuf_vc`) are thin shims over these.
+```rust
+let signed = Cbor::sign(&unsigned_cbor, Algorithm::MlDsa65, &private_key)?;
+Cbor::verify_auto(&signed, &public_key)?;
+```
 
 ### WASM/JavaScript API
 

--- a/README.md
+++ b/README.md
@@ -288,17 +288,24 @@ ML-DSA signing is **hedged** (FIPS 204's randomized variant), so ML-DSA signatur
 ```rust
 use verifiable_credential_toolkit::{generate_keypair, Algorithm};
 
+// Ed25519 (classical). The algorithm travels with each key.
 let keypair = generate_keypair(Algorithm::Ed25519);
+// Post-quantum instead — identical API, just a different Algorithm:
+// let keypair = generate_keypair(Algorithm::MlDsa44);
+// let keypair = generate_keypair(Algorithm::MlDsa65);
+// let keypair = generate_keypair(Algorithm::MlDsa87);
+
 // keypair.signing_key:   SigningKey   — keep secret
 // keypair.verifying_key: VerifyingKey — distribute to verifiers
+// Distinct types (a public key can't be passed where a private key is expected),
+// each carrying its Algorithm, so the same sign/verify works for every algorithm.
 
-// SigningKey and VerifyingKey are distinct types, so a public key can never be
-// passed where a private key is expected (and vice versa) — it's a compile error.
-// Each key carries its Algorithm, so the same sign/verify works for any algorithm.
-
-// Save the raw key bytes to files
+// Save the raw key bytes to files.
 std::fs::write("issuer.priv", keypair.signing_key.as_bytes()).unwrap();
 std::fs::write("issuer.pub", keypair.verifying_key.as_bytes()).unwrap();
+
+// Prefer raw bytes (HSM, wasm, or cross-language interop)? Skip the typed keys:
+// let (private_key, public_key) = generate_keypair_bytes(Algorithm::Ed25519);
 ```
 
 #### Construct a Credential
@@ -308,18 +315,32 @@ builder (which mirrors the `Proof` builder — required fields up front, optiona
 setters chained, then `.build()`):
 
 ```rust
-use verifiable_credential_toolkit::{Issuer, UnsignedVerifiableCredential};
+use verifiable_credential_toolkit::{Issuer, LanguageValue, UnsignedVerifiableCredential};
 use url::Url;
 use serde_json::json;
 
+// Option A — build it programmatically with the fluent builder.
 let unsigned_vc = UnsignedVerifiableCredential::builder(
     vec![Url::parse("https://www.w3.org/ns/credentials/v2").unwrap()],
     vec!["VerifiableCredential".to_string()],
     Issuer::Url(Url::parse("https://example.com/issuer").unwrap()),
+    // Or an issuer object carrying extra properties:
+    // Issuer::Object(IssuerObject { id: Url::parse("https://example.com/issuer").unwrap(),
+    //     additional_properties: Some(std::collections::HashMap::from([("name".into(), json!("Acme"))])) }),
     json!({ "id": "urn:uuid:device-1", "name": "Sensor A" }),
 )
 .id(Url::parse("urn:uuid:9a3e3c0e-2db0-412a-95c7-cf5520ba78df").unwrap())
+// Every optional field is a chainable setter before .build():
+// .name(LanguageValue::PlainString("Device Certificate".to_string()))
+// .description(LanguageValue::PlainString("Manufacturer-issued".to_string()))
+// .valid_from(chrono::Utc::now())
+// .valid_until(chrono::Utc::now() + chrono::Duration::days(365))
+// .credential_status(status)
+// .credential_schema(vec![credential_schema])
 .build();
+
+// Option B — deserialize one from JSON (a file, an API response, …):
+// let unsigned_vc: UnsignedVerifiableCredential = serde_json::from_str(vc_json)?;
 ```
 
 #### Sign a Credential
@@ -332,12 +353,16 @@ let vc_json = std::fs::read_to_string("credential.json").unwrap();
 let unsigned_vc: UnsignedVerifiableCredential =
     serde_json::from_str(&vc_json).expect("Invalid VC JSON");
 
-// Load private key (validates the length matches the algorithm)
+// Load a private key (length-checked against the algorithm). Pass the Algorithm
+// that matches the key you loaded — e.g. Algorithm::MlDsa65 for an ML-DSA-65 key.
 let signing_key = SigningKey::new(Algorithm::Ed25519, &std::fs::read("issuer.priv").unwrap())
     .expect("Invalid private key");
 
-// Sign — produces a VerifiableCredential with a proof attached
+// Sign — produces a VerifiableCredential with a DataIntegrityProof attached.
 let signed_vc = unsigned_vc.sign(&signing_key).expect("Signing failed");
+
+// Raw-bytes alternative (no typed key) — pass the algorithm and key bytes directly:
+// let signed_vc = unsigned_vc.sign_with_algorithm(Algorithm::Ed25519, &private_key_bytes)?;
 
 // Serialise and save
 let output = serde_json::to_string_pretty(&signed_vc).unwrap();
@@ -358,11 +383,64 @@ let signed_vc: VerifiableCredential =
 let verifying_key = VerifyingKey::new(Algorithm::Ed25519, &std::fs::read("issuer.pub").unwrap())
     .expect("Invalid public key");
 
-// Verify — checks signature AND validity period (validFrom/validUntil)
+// Verify — checks the signature, the validity period (validFrom/validUntil), and
+// that the proof's cryptosuite matches the key's algorithm.
 match signed_vc.verify(&verifying_key) {
     Ok(()) => println!("Credential is valid and untampered"),
     Err(e) => eprintln!("Verification failed: {}", e),
 }
+
+// Raw-bytes alternatives (public key as &[u8]):
+// signed_vc.verify_auto(&public_key_bytes)?;                              // reads the algorithm from proof.cryptosuite
+// signed_vc.verify_with_algorithm(Algorithm::Ed25519, &public_key_bytes)?; // caller asserts the algorithm
+```
+
+#### Sign & Verify in CBOR or Protobuf
+
+Every algorithm works across JSON, CBOR, and Protobuf. Each wire format is a
+`CredentialCodec`; because the signature is over the format-independent JCS
+canonical form, a credential signed in one format verifies in any other.
+
+```rust
+use verifiable_credential_toolkit::{
+    Algorithm,
+    bindings::{cbor::Cbor, protobuf::Protobuf, CredentialCodec},
+};
+
+// Encode an unsigned credential to CBOR, sign it, and verify — all on bytes.
+let unsigned_bytes = Cbor::encode_unsigned(&unsigned_vc)?;
+let signed_bytes = Cbor::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key)?;
+Cbor::verify_auto(&signed_bytes, &public_key)?;   // reads the algorithm from the proof
+// Assert the algorithm explicitly instead:
+// Cbor::verify(&signed_bytes, Algorithm::Ed25519, &public_key)?;
+
+// Protobuf is the same trait — swap Cbor for Protobuf (and any algorithm):
+// let signed_pb = Protobuf::sign(&Protobuf::encode_unsigned(&unsigned_vc)?, Algorithm::MlDsa65, &private_key)?;
+// Protobuf::verify_auto(&signed_pb, &public_key)?;
+
+// Cross-format: re-encode a signed credential and it still verifies.
+// let as_protobuf = Protobuf::encode_signed(&Cbor::decode_signed(&signed_bytes)?)?;
+// Protobuf::verify_auto(&as_protobuf, &public_key)?;
+```
+
+#### Sign externally (HSM / out-of-process)
+
+Get the exact canonical bytes with `signing_payload`, sign them wherever the key
+lives, then wrap the raw signature in a proof — nothing else touches the key.
+
+```rust
+use verifiable_credential_toolkit::{Algorithm, Proof, VerifiableCredential};
+use multibase::Base;
+
+let payload = unsigned_vc.signing_payload()?;    // JCS-canonical bytes to sign
+let raw_signature: Vec<u8> = hsm_sign(&payload); // your HSM / external signer returns raw bytes
+
+let proof = Proof::new_data_integrity(
+    Algorithm::MlDsa65.cryptosuite(),
+    multibase::encode(Base::Base58Btc, raw_signature),
+);
+let signed_vc = VerifiableCredential::from_parts(unsigned_vc, proof);
+signed_vc.verify_auto(&public_key)?;
 ```
 
 #### Sign with JSON Schema Validation
@@ -385,20 +463,14 @@ let signing_key = SigningKey::new(Algorithm::Ed25519, &std::fs::read("issuer.pri
 let schema: serde_json::Value =
     serde_json::from_str(&std::fs::read_to_string("device_schema.json").unwrap()).unwrap();
 
-// Validate then sign — validate fails if credentialSubject doesn't match the schema
+// Validate then sign — validate fails (VcError::SchemaMismatch) if the
+// credentialSubject doesn't match the schema.
 unsigned_vc
     .validate(&SchemaSource::Inline(&schema))
+    // Other schema sources:
+    // .validate(&SchemaSource::Url("https://example.com/schemas/device.json"))  // fetched at validation time (native only)
+    // .validate(&SchemaSource::None)                                            // no-op — skip validation
     .expect("Schema validation failed");
-let signed_vc = unsigned_vc.sign(&signing_key).expect("Signing failed");
-```
-
-`SchemaSource` can also fetch a schema from a URL at validation time (native Rust
-only — the `Url` variant is not available in WASM):
-
-```rust
-unsigned_vc
-    .validate(&SchemaSource::Url("https://example.com/schemas/device.json"))
-    .expect("Failed to fetch schema or validate");
 let signed_vc = unsigned_vc.sign(&signing_key).expect("Signing failed");
 ```
 
@@ -412,14 +484,25 @@ use url::Url;
 
 let mut signed_vc = unsigned_vc.sign(&signing_key).unwrap();
 
-// Builder pattern
+// Builder pattern (consuming self, chainable).
 signed_vc.proof = signed_vc.proof
     .set_verification_method("did:example:issuer#key-1".to_string())
-    .set_crypto_suite("eddsa-jcs-2022".to_string())
     .set_created(Utc::now())
     .set_expires(Utc::now() + Duration::days(365))
     .set_domain(vec!["https://example.com".to_string()])
     .set_nonce(vec!["abc123".to_string()]);
+    // Other setters:
+    // .set_id(Url::parse("urn:uuid:...").unwrap())
+    // .set_proof_purpose("authentication".to_string())
+    // .set_challenge("challenge-from-verifier".to_string())
+    // .set_previous_proof("urn:uuid:prior-proof".to_string())
+
+// Or set fields directly:
+// signed_vc.proof.created = Some(Utc::now());
+// signed_vc.proof.domain = Some(vec!["https://example.com".to_string()]);
+
+// Note: don't change `cryptosuite` or `proofValue` after signing — that would make
+// the proof no longer match the signature.
 ```
 
 #### Build a Verifiable Presentation
@@ -436,6 +519,12 @@ let vp = VerifiablePresentation {
     presentation_type: vec!["VerifiablePresentation".to_string()],
     verifiable_credential: Some(vec![signed_vc]),
     holder: None,
+    // A holder as a bare URL, or an object with extra properties:
+    // holder: Some(Holder::Url(Url::parse("did:example:holder-123").unwrap())),
+    // holder: Some(Holder::Object(HolderObject {
+    //     id: Url::parse("did:example:holder-123").unwrap(),
+    //     additional_properties: None,
+    // })),
 };
 
 let vp_json = serde_json::to_string_pretty(&vp).unwrap();
@@ -589,6 +678,8 @@ wasm-bindgen --target nodejs --out-dir pkg \
 
         // Generate a fresh keypair
         const keypair = generate_keypair();
+        // Post-quantum: generate_keypair_for("ML-DSA-65"), then sign_with_algorithm +
+        // verify_auto. CBOR/Protobuf helpers (sign_cbor_vc, …) are exported too.
 
         // Define a credential
         const unsignedVC = {
@@ -629,6 +720,8 @@ import {
 
 // Generate keys (or load existing ones)
 const keypair = generate_keypair();
+// Post-quantum instead (label: "ML-DSA-44" | "ML-DSA-65" | "ML-DSA-87"):
+// const keypair = generate_keypair_for("ML-DSA-65");
 
 // Create a credential
 const unsignedVC = {
@@ -671,6 +764,19 @@ const isValidWithSchema = verify_with_schema_check(
   schema,
 );
 console.log("Valid with schema:", isValidWithSchema);
+
+// ── Other options (import the functions you use) ─────────────────────────
+// Any algorithm — pass a label and raw key bytes:
+// const signedVC = sign_with_algorithm(unsignedVC, "ML-DSA-65", keypair.signing_key());
+// const ok = verify_auto(signedVC, keypair.verifying_key());                    // reads the cryptosuite from the proof
+// const ok = verify_with_algorithm(signedVC, "ML-DSA-65", keypair.verifying_key());
+//
+// CBOR / Protobuf (operate on Uint8Array bytes; signed once, verifies in any format):
+// const cbor   = encode_unsigned_vc_to_cbor(unsignedVC);
+// const signed = sign_cbor_vc(cbor, keypair.signing_key());                     // Ed25519
+// const signed = sign_cbor_vc_with_algorithm(cbor, "ML-DSA-65", keypair.signing_key());
+// const ok     = verify_cbor_vc_auto(signed, keypair.verifying_key());
+// (…and encode_*_to_protobuf / sign_protobuf_vc[_with_algorithm] / verify_protobuf_vc_auto)
 ```
 
 #### TypeScript Types

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ A Verifiable Credential is a JSON object with this structure:
     "type": "DataIntegrityProof",
     "cryptosuite": "eddsa-jcs-2022",
     "proofPurpose": "assertionMethod",
-    "proofValue": "base64-encoded-signature...",
+    "proofValue": "z-multibase-encoded-signature...",
   },
 }
 ```
@@ -256,13 +256,17 @@ signed.verify_auto(&public_key)?;            // reads the algorithm from proof.c
 
 ### Bring-your-own / external signatures
 
-If you compute a signature outside the crate (e.g. in an HSM), call [`signing_payload`] to get the exact JCS bytes to sign, then wrap the result with `Proof::new_data_integrity(cryptosuite, base64_signature)` (or `Proof::set_proof_value`) and `VerifiableCredential::from_parts(unsigned, proof)`. The `proofValue` is the base64-encoded raw signature.
+If you compute a signature outside the crate (e.g. in an HSM), call [`signing_payload`] to get the exact JCS bytes to sign, then wrap the result with `Proof::new_data_integrity(cryptosuite, proof_value)` (or `Proof::set_proof_value`) and `VerifiableCredential::from_parts(unsigned, proof)`. The `proofValue` is the **multibase (base58btc)** encoding of the raw signature bytes — i.e. `multibase::encode(Base58Btc, signature)`, a `z`-prefixed string.
 
 ### Canonical signing
 
-The signature is computed over the credential serialized with **JCS (JSON Canonicalization Scheme, [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785))**, used by every cryptosuite above. Canonicalization sorts object keys and normalizes number formatting, so the signed bytes are independent of field ordering. This means a signature stays valid across a serialize/deserialize round-trip and across encodings (JSON, CBOR, Protobuf) — the proof is over the credential's canonical form, not the wire bytes. The emitted proof is a `DataIntegrityProof` whose `cryptosuite` matches the signing algorithm.
+The signature is computed over the credential serialized with **JCS (JSON Canonicalization Scheme, [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785))**, used by every cryptosuite above. Canonicalization sorts object keys and normalizes number formatting, so the signed bytes are independent of field ordering. This means a signature stays valid across a serialize/deserialize round-trip and across encodings (JSON, CBOR, Protobuf) — the proof is over the credential's canonical form, not the wire bytes. The emitted proof is a `DataIntegrityProof` whose `cryptosuite` matches the signing algorithm, with the signature stored as a multibase (base58btc) `proofValue`.
 
-> **Compatibility note:** signatures are not interchangeable with pre-0.6 releases, which signed over non-canonical JSON. Credentials issued by 0.5.x must be re-signed.
+Every algorithm works across all three formats. For CBOR and Protobuf, sign with `sign_{cbor,protobuf}_vc_with_algorithm(bytes, algorithm, private_key)` and verify with `verify_{cbor,protobuf}_vc_auto(bytes, public_key)` (reads the cryptosuite) or `..._with_algorithm`. Because the signature is over the format-independent JCS form, a credential signed in one format verifies in any other.
+
+ML-DSA signing is **hedged** (FIPS 204's randomized variant), so ML-DSA signatures are non-deterministic; Ed25519 signatures remain deterministic.
+
+> **Compatibility note:** signatures are not interchangeable across encodings of the `proofValue`. 0.5.x signed over non-canonical JSON; 0.6.x used a base64 `proofValue`; this release uses a **multibase** `proofValue`. Credentials issued by earlier versions must be re-signed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ This toolkit handles steps 1 and 3 — signing credentials and verifying them.
 
 ```rust
 use verifiable_credential_toolkit::{
-    UnsignedVerifiableCredential, generate_keypair,
+    Algorithm, UnsignedVerifiableCredential, generate_keypair,
 };
 
-// 1. Generate an Ed25519 keypair (signing_key: SigningKey, verifying_key: VerifyingKey)
-let keypair = generate_keypair();
+// 1. Generate a keypair (signing_key: SigningKey, verifying_key: VerifyingKey).
+//    The algorithm travels with each key; pass ML-DSA-44/65/87 here for post-quantum.
+let keypair = generate_keypair(Algorithm::Ed25519);
 
 // 2. Define a credential as JSON
 let vc_json = r#"{
@@ -242,7 +243,15 @@ The toolkit signs and verifies with these algorithms, selected via the [`Algorit
 | ML-DSA-65 (FIPS 204, cat. 3) | `MlDsa65` | 4032 | 1952 | `mldsa65-jcs-2025` |
 | ML-DSA-87 (FIPS 204, cat. 5) | `MlDsa87` | 4896 | 2592 | `mldsa87-jcs-2025` |
 
-ML-DSA (the NIST post-quantum signature standard) is provided via the `ml-dsa` crate. Keys are raw FIPS 204 byte strings; generate a pair with `generate_keypair_bytes(Algorithm)`.
+ML-DSA (the NIST post-quantum signature standard) is provided via the `ml-dsa` crate, and is just another `Algorithm` — there is no separate ML-DSA API. The typed `SigningKey` / `VerifyingKey` carry their algorithm, are length-checked at construction, and pair with the same `sign` / `verify` used for Ed25519 (so the algorithm can't disagree with the key, and `verify` rejects a proof whose cryptosuite names a different algorithm):
+
+```rust
+let keypair = generate_keypair(Algorithm::MlDsa65);   // typed pair, algorithm carried by the key
+let signed = unsigned.sign(&keypair.signing_key)?;
+signed.verify(&keypair.verifying_key)?;
+```
+
+For HSM, cross-language, or wasm interop where keys are just bytes, use the raw-byte path: `generate_keypair_bytes(Algorithm)` plus `sign_with_algorithm` / `verify_with_algorithm` / `verify_auto`.
 
 ```rust
 let (private_key, public_key) = generate_keypair_bytes(Algorithm::MlDsa65);
@@ -250,17 +259,7 @@ let signed = unsigned.sign_with_algorithm(Algorithm::MlDsa65, &private_key)?;
 signed.verify_auto(&public_key)?;            // reads the algorithm from proof.cryptosuite
 ```
 
-`verify_auto` dispatches on the proof's `cryptosuite`; `verify_with_algorithm` takes an explicit algorithm; `verify` is the Ed25519-typed convenience wrapper. Ed25519 keys can still be loaded as raw 32-byte files (`{timestamp}.priv` / `.pub` from the CLI tools).
-
-For ML-DSA there are also typed keys mirroring Ed25519's `SigningKey` / `VerifyingKey`: `MlDsaSigningKey` / `MlDsaVerifyingKey` carry their parameter set, are length-checked at construction, and pair with `sign_ml_dsa` / `verify_ml_dsa` so the algorithm can't disagree with the key (and `verify_ml_dsa` rejects a proof whose cryptosuite names a different parameter set). Generate them with `generate_ml_dsa_keypair(Algorithm)`:
-
-```rust
-let keypair = generate_ml_dsa_keypair(Algorithm::MlDsa65)?;     // typed pair
-let signed = unsigned.sign_ml_dsa(&keypair.signing_key)?;
-signed.verify_ml_dsa(&keypair.verifying_key)?;
-```
-
-Use the raw-byte `sign_with_algorithm` / `verify_*` path for HSM, cross-language, or wasm interop where keys are just bytes.
+`verify_auto` dispatches on the proof's `cryptosuite`; `verify_with_algorithm` takes an explicit algorithm; `verify` reads it from the typed key. Ed25519 keys can still be loaded as raw 32-byte files (`{timestamp}.priv` / `.pub` from the CLI tools) via `SigningKey::new(Algorithm::Ed25519, &bytes)`.
 
 > ⚠️ **Provisional ML-DSA cryptosuite identifiers.** The W3C `vc-di-mldsa` cryptosuite is still a Working Draft with no finalized identifier, multikey codec, or canonicalization choice. The `mldsa{44,65,87}-jcs-2025` strings above are a **bilateral convention** for closed deployments (e.g. NATO IC 2026 partners) — signing and verifying parties must agree on them out of band and document them; they are not interoperable with arbitrary third-party verifiers until the standard finalizes.
 
@@ -287,18 +286,19 @@ ML-DSA signing is **hedged** (FIPS 204's randomized variant), so ML-DSA signatur
 #### Generate a Keypair
 
 ```rust
-use verifiable_credential_toolkit::generate_keypair;
+use verifiable_credential_toolkit::{generate_keypair, Algorithm};
 
-let keypair = generate_keypair();
+let keypair = generate_keypair(Algorithm::Ed25519);
 // keypair.signing_key:   SigningKey   — keep secret
 // keypair.verifying_key: VerifyingKey — distribute to verifiers
 
 // SigningKey and VerifyingKey are distinct types, so a public key can never be
 // passed where a private key is expected (and vice versa) — it's a compile error.
+// Each key carries its Algorithm, so the same sign/verify works for any algorithm.
 
-// Save the raw 32-byte representations to files
-std::fs::write("issuer.priv", keypair.signing_key.to_bytes()).unwrap();
-std::fs::write("issuer.pub", keypair.verifying_key.to_bytes()).unwrap();
+// Save the raw key bytes to files
+std::fs::write("issuer.priv", keypair.signing_key.as_bytes()).unwrap();
+std::fs::write("issuer.pub", keypair.verifying_key.as_bytes()).unwrap();
 ```
 
 #### Construct a Credential
@@ -325,15 +325,15 @@ let unsigned_vc = UnsignedVerifiableCredential::builder(
 #### Sign a Credential
 
 ```rust
-use verifiable_credential_toolkit::{SigningKey, UnsignedVerifiableCredential};
+use verifiable_credential_toolkit::{Algorithm, SigningKey, UnsignedVerifiableCredential};
 
 // Load credential from JSON (from a file, API response, etc.)
 let vc_json = std::fs::read_to_string("credential.json").unwrap();
 let unsigned_vc: UnsignedVerifiableCredential =
     serde_json::from_str(&vc_json).expect("Invalid VC JSON");
 
-// Load private key (validates it is exactly 32 bytes)
-let signing_key = SigningKey::from_bytes(&std::fs::read("issuer.priv").unwrap())
+// Load private key (validates the length matches the algorithm)
+let signing_key = SigningKey::new(Algorithm::Ed25519, &std::fs::read("issuer.priv").unwrap())
     .expect("Invalid private key");
 
 // Sign — produces a VerifiableCredential with a proof attached
@@ -347,15 +347,15 @@ std::fs::write("credential_signed.json", output).unwrap();
 #### Verify a Credential
 
 ```rust
-use verifiable_credential_toolkit::{VerifiableCredential, VerifyingKey};
+use verifiable_credential_toolkit::{Algorithm, VerifiableCredential, VerifyingKey};
 
 // Load the signed credential
 let vc_json = std::fs::read_to_string("credential_signed.json").unwrap();
 let signed_vc: VerifiableCredential =
     serde_json::from_str(&vc_json).expect("Invalid signed VC");
 
-// Load the issuer's public key (validates it is exactly 32 bytes)
-let verifying_key = VerifyingKey::from_bytes(&std::fs::read("issuer.pub").unwrap())
+// Load the issuer's public key (validates the length matches the algorithm)
+let verifying_key = VerifyingKey::new(Algorithm::Ed25519, &std::fs::read("issuer.pub").unwrap())
     .expect("Invalid public key");
 
 // Verify — checks signature AND validity period (validFrom/validUntil)
@@ -374,11 +374,11 @@ Schema validation is a separate, composable step: call `validate` with a
 the schema comes from.
 
 ```rust
-use verifiable_credential_toolkit::{SchemaSource, SigningKey, UnsignedVerifiableCredential};
+use verifiable_credential_toolkit::{Algorithm, SchemaSource, SigningKey, UnsignedVerifiableCredential};
 
 let unsigned_vc: UnsignedVerifiableCredential =
     serde_json::from_str(&std::fs::read_to_string("credential.json").unwrap()).unwrap();
-let signing_key = SigningKey::from_bytes(&std::fs::read("issuer.priv").unwrap())
+let signing_key = SigningKey::new(Algorithm::Ed25519, &std::fs::read("issuer.priv").unwrap())
     .expect("Invalid private key");
 
 // Load the schema
@@ -711,19 +711,22 @@ class KeyPair {
 
 | Function / Method                                                                                                | Description                                                                 |
 | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `generate_keypair() → KeyPair`                                                                                   | Generate a new Ed25519 `KeyPair { signing_key, verifying_key }`             |
-| `SigningKey::from_bytes(&[u8]) → Result<SigningKey>`                                                             | Parse a 32-byte private key (errors otherwise)                              |
-| `VerifyingKey::from_bytes(&[u8]) → Result<VerifyingKey>`                                                         | Parse a 32-byte public key (errors otherwise)                              |
+| `generate_keypair(Algorithm) → KeyPair`                                                                          | Generate a `KeyPair { signing_key, verifying_key }` for any algorithm       |
+| `generate_keypair_bytes(Algorithm) → (Vec<u8>, Vec<u8>)`                                                         | Generate raw `(private, public)` key bytes (HSM / wasm / cross-language interop) |
+| `SigningKey::new(Algorithm, &[u8]) → Result<SigningKey>`                                                         | Wrap private-key bytes, length-checked against the algorithm                |
+| `VerifyingKey::new(Algorithm, &[u8]) → Result<VerifyingKey>`                                                     | Wrap public-key bytes, length-checked against the algorithm                 |
 | `UnsignedVerifiableCredential::builder(context, type, issuer, subject) → …Builder`                              | Fluent builder; chain optional setters then `.build()`                      |
 | `UnsignedVerifiableCredential::validate(&SchemaSource) → Result<()>`                                             | Validate `credentialSubject` against a `SchemaSource` (`None` / `Inline` / `Url`) |
-| `UnsignedVerifiableCredential::sign(&SigningKey) → Result<VerifiableCredential>`                                 | Sign a credential (call `validate` first for schema checks)                 |
+| `UnsignedVerifiableCredential::sign(&SigningKey) → Result<VerifiableCredential>`                                 | Sign a credential; algorithm read from the key (call `validate` first for schema checks) |
+| `UnsignedVerifiableCredential::sign_with_algorithm(Algorithm, &[u8]) → Result<VerifiableCredential>`             | Sign with an explicit algorithm and raw private-key bytes                   |
 | `VerifiableCredential::validate(&SchemaSource) → Result<()>`                                                     | Validate the embedded `credentialSubject` against a `SchemaSource`          |
-| `VerifiableCredential::verify(&VerifyingKey) → Result<()>`                                                       | Verify signature and check validity period                                  |
+| `VerifiableCredential::verify(&VerifyingKey) → Result<()>`                                                       | Verify signature + validity period; checks the proof's cryptosuite matches the key's algorithm |
+| `VerifiableCredential::verify_auto(&[u8]) → Result<()>` / `verify_with_algorithm(Algorithm, &[u8])`              | Verify from raw public-key bytes, dispatching on the proof's cryptosuite (or an explicit algorithm) |
 | `VerifiableCredential::to_unsigned() → UnsignedVerifiableCredential`                                             | Strip the proof to get back an unsigned credential                          |
 
 All fallible operations return `Result<_, VcError>` — a typed error enum you can match on (e.g. `VcError::Expired`, `VcError::SchemaMismatch`, `VcError::SignatureVerificationFailed`).
 
-`SigningKey` and `VerifyingKey` are distinct newtypes over 32 bytes, so a private and public key can never be swapped at a call site — the mismatch is a compile error.
+`SigningKey` and `VerifyingKey` are distinct types that each carry their `Algorithm` (Ed25519 or an ML-DSA parameter set), so a private and public key can never be swapped at a call site — the mismatch is a compile error — and `sign` / `verify` read the algorithm from the key.
 
 `SchemaSource` selects where the JSON Schema comes from: `SchemaSource::None`, `SchemaSource::Inline(&Value)`, or `SchemaSource::Url(&str)` (native only). To validate and sign in one expression: `vc.validate(&schema).and_then(|()| vc.sign(&signing_key))`.
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,7 @@ A typical VC workflow looks like this:
 └──────────┘         └──────────┘         └──────────┘
 ```
 
-1. An **Issuer** (e.g. a device manufacturer, certificate authority) creates a credential containing claims (e.g. "this device has ID X and model Y") and signs it with their private key.
-2. A **Holder** (e.g. the device owner) receives and stores the signed credential.
-3. A **Verifier** (e.g. a system accepting the device onto a network) checks the signature using the issuer's public key. If valid, the claims are trustworthy.
-
-This toolkit handles steps 1 and 3 — signing credentials and verifying them.
+An **issuer** signs a credential with their private key; a **holder** stores and presents it; a **verifier** checks the signature with the issuer's public key. This toolkit handles the issuer and verifier ends — signing and verifying.
 
 ---
 
@@ -243,37 +239,13 @@ The toolkit signs and verifies with these algorithms, selected via the [`Algorit
 | ML-DSA-65 (FIPS 204, cat. 3) | `MlDsa65` | 4032 | 1952 | `mldsa65-jcs-2025` |
 | ML-DSA-87 (FIPS 204, cat. 5) | `MlDsa87` | 4896 | 2592 | `mldsa87-jcs-2025` |
 
-ML-DSA (the NIST post-quantum signature standard) is provided via the `ml-dsa` crate, and is just another `Algorithm` — there is no separate ML-DSA API. The typed `SigningKey` / `VerifyingKey` carry their algorithm, are length-checked at construction, and pair with the same `sign` / `verify` used for Ed25519 (so the algorithm can't disagree with the key, and `verify` rejects a proof whose cryptosuite names a different algorithm):
-
-```rust
-let keypair = generate_keypair(Algorithm::MlDsa65);   // typed pair, algorithm carried by the key
-let signed = unsigned.sign(&keypair.signing_key)?;
-signed.verify(&keypair.verifying_key)?;
-```
-
-For HSM, cross-language, or wasm interop where keys are just bytes, use the raw-byte path: `generate_keypair_bytes(Algorithm)` plus `sign_with_algorithm` / `verify_with_algorithm` / `verify_auto`.
-
-```rust
-let (private_key, public_key) = generate_keypair_bytes(Algorithm::MlDsa65);
-let signed = unsigned.sign_with_algorithm(Algorithm::MlDsa65, &private_key)?;
-signed.verify_auto(&public_key)?;            // reads the algorithm from proof.cryptosuite
-```
-
-`verify_auto` dispatches on the proof's `cryptosuite`; `verify_with_algorithm` takes an explicit algorithm; `verify` reads it from the typed key. Ed25519 keys can still be loaded as raw 32-byte files (`{timestamp}.priv` / `.pub` from the CLI tools) via `SigningKey::new(Algorithm::Ed25519, &bytes)`.
+ML-DSA (the NIST post-quantum standard) comes from the `ml-dsa` crate and is just another `Algorithm` — no separate API. Typed keys carry their algorithm and use the same `sign` / `verify` as Ed25519; a raw-byte path (`generate_keypair_bytes`, `sign_with_algorithm`, `verify_auto`) covers HSM / wasm / cross-language interop. See [Usage](#usage) for both.
 
 > ⚠️ **Provisional ML-DSA cryptosuite identifiers.** The W3C `vc-di-mldsa` cryptosuite is still a Working Draft with no finalized identifier, multikey codec, or canonicalization choice. The `mldsa{44,65,87}-jcs-2025` strings above are a **bilateral convention** for closed deployments (e.g. NATO IC 2026 partners) — signing and verifying parties must agree on them out of band and document them; they are not interoperable with arbitrary third-party verifiers until the standard finalizes.
 
-### Bring-your-own / external signatures
-
-If you compute a signature outside the crate (e.g. in an HSM), call [`signing_payload`] to get the exact JCS bytes to sign, then wrap the result with `Proof::new_data_integrity(cryptosuite, proof_value)` (or `Proof::set_proof_value`) and `VerifiableCredential::from_parts(unsigned, proof)`. The `proofValue` is the **multibase (base58btc)** encoding of the raw signature bytes — i.e. `multibase::encode(Base58Btc, signature)`, a `z`-prefixed string.
-
 ### Canonical signing
 
-The signature is computed over the credential serialized with **JCS (JSON Canonicalization Scheme, [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785))**, used by every cryptosuite above. Canonicalization sorts object keys and normalizes number formatting, so the signed bytes are independent of field ordering. This means a signature stays valid across a serialize/deserialize round-trip and across encodings (JSON, CBOR, Protobuf) — the proof is over the credential's canonical form, not the wire bytes. The emitted proof is a `DataIntegrityProof` whose `cryptosuite` matches the signing algorithm, with the signature stored as a multibase (base58btc) `proofValue`.
-
-Every algorithm works across all three formats. For CBOR and Protobuf, sign with `Cbor::sign(bytes, algorithm, private_key)` / `Protobuf::sign(...)` and verify with `Cbor::verify_auto(bytes, public_key)` (reads the cryptosuite) or `Cbor::verify(bytes, algorithm, public_key)`. Because the signature is over the format-independent JCS form, a credential signed in one format verifies in any other.
-
-ML-DSA signing is **hedged** (FIPS 204's randomized variant), so ML-DSA signatures are non-deterministic; Ed25519 signatures remain deterministic.
+Signatures are computed over the credential in **JCS canonical form** ([RFC 8785](https://www.rfc-editor.org/rfc/rfc8785)) — keys sorted, numbers normalized — so a signature survives a serialize/deserialize round-trip and is identical across JSON, CBOR, and Protobuf (the proof is over the canonical form, not the wire bytes). The proof is a `DataIntegrityProof` with a multibase (base58btc) `proofValue`. ML-DSA signing is **hedged** (non-deterministic); Ed25519 is deterministic.
 
 > **Compatibility note:** signatures are not interchangeable across encodings of the `proofValue`. 0.5.x signed over non-canonical JSON; 0.6.x used a base64 `proofValue`; **0.7.0** uses a **multibase** `proofValue`. Credentials issued by earlier versions must be re-signed. 0.7.0 is also breaking in that `verify` now rejects an unknown or missing `cryptosuite`, and `VcError::SignatureVerificationFailed` is a unit variant.
 
@@ -922,13 +894,10 @@ Working examples are included in the repository:
 | [`wasm_nodejs_example_usage/`](./wasm_nodejs_example_usage/) | Node.js signing, verification, and schema validation |
 | [`examples/`](./examples/)                                   | Rust examples (run with `cargo run --example`)       |
 
-Both examples are written in TypeScript and exercise the full WASM API:
-sign/verify, tamper + wrong-key rejection, JSON-Schema validation, validity
-periods, the `normalize_*` helpers, and the CBOR + Protobuf bindings. The
-CBOR/Protobuf sections do a full round-trip entirely in JS — encoding the
-credential object to bytes, decoding it back, signing, and verifying — so no
-pre-encoded fixtures are needed. The Node example self-checks every result (and
-exits non-zero on failure); the browser example renders each result on the page.
+Both WASM examples are TypeScript and exercise the full API — sign/verify, tamper
+and wrong-key rejection, schema validation, and the CBOR/Protobuf bindings. The
+Node example self-checks every result (non-zero exit on failure); the browser
+example renders results on the page.
 
 ### Running the Node.js Example
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Verifiable Credential Toolkit
 
-A Rust library (with WASM/JavaScript bindings) for creating, signing, and verifying [W3C Verifiable Credentials](https://www.w3.org/TR/vc-data-model-2.0/). It uses Ed25519 digital signatures to ensure credentials are tamper-proof and can be independently verified.
+A Rust library (with WASM/JavaScript bindings) for creating, signing, and verifying [W3C Verifiable Credentials](https://www.w3.org/TR/vc-data-model-2.0/). It signs with Ed25519 or post-quantum ML-DSA (FIPS 204) to ensure credentials are tamper-proof and can be independently verified.
 
 ## Table of Contents
 
@@ -231,18 +231,36 @@ A Verifiable Credential is a JSON object with this structure:
 }
 ```
 
-### Ed25519 Keys
+### Signature algorithms
 
-This toolkit uses **Ed25519**, a fast and widely-supported digital signature algorithm. Keys are compact (32 bytes each) and signatures are 64 bytes.
+The toolkit signs and verifies with these algorithms, selected via the [`Algorithm`] enum:
 
-- **Private key** (signing key): 32 bytes. Keep this secret. Used by the issuer to sign credentials.
-- **Public key** (verifying key): 32 bytes. Share this freely. Used by anyone to verify a credential's authenticity.
+| Algorithm | `Algorithm` variant | Private key | Public key | `cryptosuite` |
+|---|---|---:|---:|---|
+| Ed25519 (EdDSA) | `Ed25519` | 32 | 32 | `eddsa-jcs-2022` |
+| ML-DSA-44 (FIPS 204, cat. 2) | `MlDsa44` | 2560 | 1312 | `mldsa44-jcs-2025` |
+| ML-DSA-65 (FIPS 204, cat. 3) | `MlDsa65` | 4032 | 1952 | `mldsa65-jcs-2025` |
+| ML-DSA-87 (FIPS 204, cat. 5) | `MlDsa87` | 4896 | 2592 | `mldsa87-jcs-2025` |
 
-Keys are stored as raw binary files (not PEM/DER). The CLI tools generate files named `{timestamp}.priv` and `{timestamp}.pub`.
+ML-DSA (the NIST post-quantum signature standard) is provided via the `ml-dsa` crate. Keys are raw FIPS 204 byte strings; generate a pair with `generate_keypair_bytes(Algorithm)`.
+
+```rust
+let (private_key, public_key) = generate_keypair_bytes(Algorithm::MlDsa65);
+let signed = unsigned.sign_with_algorithm(Algorithm::MlDsa65, &private_key)?;
+signed.verify_auto(&public_key)?;            // reads the algorithm from proof.cryptosuite
+```
+
+`verify_auto` dispatches on the proof's `cryptosuite`; `verify_with_algorithm` takes an explicit algorithm; `verify` is the Ed25519-typed convenience wrapper. Ed25519 keys can still be loaded as raw 32-byte files (`{timestamp}.priv` / `.pub` from the CLI tools).
+
+> ⚠️ **Provisional ML-DSA cryptosuite identifiers.** The W3C `vc-di-mldsa` cryptosuite is still a Working Draft with no finalized identifier, multikey codec, or canonicalization choice. The `mldsa{44,65,87}-jcs-2025` strings above are a **bilateral convention** for closed deployments (e.g. NATO IC 2026 partners) — signing and verifying parties must agree on them out of band and document them; they are not interoperable with arbitrary third-party verifiers until the standard finalizes.
+
+### Bring-your-own / external signatures
+
+If you compute a signature outside the crate (e.g. in an HSM), call [`signing_payload`] to get the exact JCS bytes to sign, then wrap the result with `Proof::new_data_integrity(cryptosuite, base64_signature)` (or `Proof::set_proof_value`) and `VerifiableCredential::from_parts(unsigned, proof)`. The `proofValue` is the base64-encoded raw signature.
 
 ### Canonical signing
 
-The signature is computed over the credential serialized with **JCS (JSON Canonicalization Scheme, [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785))**, as used by the `eddsa-jcs-2022` cryptosuite. Canonicalization sorts object keys and normalizes number formatting, so the signed bytes are independent of field ordering. This means a signature stays valid across a serialize/deserialize round-trip and across encodings (JSON, CBOR, Protobuf) — the proof is over the credential's canonical form, not the wire bytes. The emitted proof is a `DataIntegrityProof` with `cryptosuite: "eddsa-jcs-2022"`.
+The signature is computed over the credential serialized with **JCS (JSON Canonicalization Scheme, [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785))**, used by every cryptosuite above. Canonicalization sorts object keys and normalizes number formatting, so the signed bytes are independent of field ordering. This means a signature stays valid across a serialize/deserialize round-trip and across encodings (JSON, CBOR, Protobuf) — the proof is over the credential's canonical form, not the wire bytes. The emitted proof is a `DataIntegrityProof` whose `cryptosuite` matches the signing algorithm.
 
 > **Compatibility note:** signatures are not interchangeable with pre-0.6 releases, which signed over non-canonical JSON. Credentials issued by 0.5.x must be re-signed.
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-verifiable-credential-toolkit = "0.6"
+verifiable-credential-toolkit = "0.7"
 ```
 
 Or install directly from GitHub:
@@ -252,6 +252,16 @@ signed.verify_auto(&public_key)?;            // reads the algorithm from proof.c
 
 `verify_auto` dispatches on the proof's `cryptosuite`; `verify_with_algorithm` takes an explicit algorithm; `verify` is the Ed25519-typed convenience wrapper. Ed25519 keys can still be loaded as raw 32-byte files (`{timestamp}.priv` / `.pub` from the CLI tools).
 
+For ML-DSA there are also typed keys mirroring Ed25519's `SigningKey` / `VerifyingKey`: `MlDsaSigningKey` / `MlDsaVerifyingKey` carry their parameter set, are length-checked at construction, and pair with `sign_ml_dsa` / `verify_ml_dsa` so the algorithm can't disagree with the key (and `verify_ml_dsa` rejects a proof whose cryptosuite names a different parameter set). Generate them with `generate_ml_dsa_keypair(Algorithm)`:
+
+```rust
+let keypair = generate_ml_dsa_keypair(Algorithm::MlDsa65)?;     // typed pair
+let signed = unsigned.sign_ml_dsa(&keypair.signing_key)?;
+signed.verify_ml_dsa(&keypair.verifying_key)?;
+```
+
+Use the raw-byte `sign_with_algorithm` / `verify_*` path for HSM, cross-language, or wasm interop where keys are just bytes.
+
 > ⚠️ **Provisional ML-DSA cryptosuite identifiers.** The W3C `vc-di-mldsa` cryptosuite is still a Working Draft with no finalized identifier, multikey codec, or canonicalization choice. The `mldsa{44,65,87}-jcs-2025` strings above are a **bilateral convention** for closed deployments (e.g. NATO IC 2026 partners) — signing and verifying parties must agree on them out of band and document them; they are not interoperable with arbitrary third-party verifiers until the standard finalizes.
 
 ### Bring-your-own / external signatures
@@ -262,11 +272,11 @@ If you compute a signature outside the crate (e.g. in an HSM), call [`signing_pa
 
 The signature is computed over the credential serialized with **JCS (JSON Canonicalization Scheme, [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785))**, used by every cryptosuite above. Canonicalization sorts object keys and normalizes number formatting, so the signed bytes are independent of field ordering. This means a signature stays valid across a serialize/deserialize round-trip and across encodings (JSON, CBOR, Protobuf) — the proof is over the credential's canonical form, not the wire bytes. The emitted proof is a `DataIntegrityProof` whose `cryptosuite` matches the signing algorithm, with the signature stored as a multibase (base58btc) `proofValue`.
 
-Every algorithm works across all three formats. For CBOR and Protobuf, sign with `sign_{cbor,protobuf}_vc_with_algorithm(bytes, algorithm, private_key)` and verify with `verify_{cbor,protobuf}_vc_auto(bytes, public_key)` (reads the cryptosuite) or `..._with_algorithm`. Because the signature is over the format-independent JCS form, a credential signed in one format verifies in any other.
+Every algorithm works across all three formats. For CBOR and Protobuf, sign with `Cbor::sign(bytes, algorithm, private_key)` / `Protobuf::sign(...)` and verify with `Cbor::verify_auto(bytes, public_key)` (reads the cryptosuite) or `Cbor::verify(bytes, algorithm, public_key)`. Because the signature is over the format-independent JCS form, a credential signed in one format verifies in any other.
 
 ML-DSA signing is **hedged** (FIPS 204's randomized variant), so ML-DSA signatures are non-deterministic; Ed25519 signatures remain deterministic.
 
-> **Compatibility note:** signatures are not interchangeable across encodings of the `proofValue`. 0.5.x signed over non-canonical JSON; 0.6.x used a base64 `proofValue`; this release uses a **multibase** `proofValue`. Credentials issued by earlier versions must be re-signed.
+> **Compatibility note:** signatures are not interchangeable across encodings of the `proofValue`. 0.5.x signed over non-canonical JSON; 0.6.x used a base64 `proofValue`; **0.7.0** uses a **multibase** `proofValue`. Credentials issued by earlier versions must be re-signed. 0.7.0 is also breaking in that `verify` now rejects an unknown or missing `cryptosuite`, and `VcError::SignatureVerificationFailed` is a unit variant.
 
 ---
 
@@ -739,14 +749,22 @@ Cbor::verify_auto(&signed, &public_key)?;
 | Function                                                          | Description                                                              |
 | ----------------------------------------------------------------- | ------------------------------------------------------------------------ |
 | `generate_keypair() → KeyPair`                                    | Generate a new Ed25519 keypair                                           |
-| `sign(unsignedVC, privateKey) → VerifiableCredential`             | Sign a credential (throws on error)                                      |
-| `verify(signedVC, publicKey) → boolean`                           | Verify a signed credential                                               |
-| `verify_with_schema_check(signedVC, publicKey, schema) → boolean` | Verify with JSON Schema validation                                       |
-| `sign_cbor_vc(unsignedBytes, privateKey) → Uint8Array`            | Sign a CBOR-encoded credential                                           |
-| `verify_cbor_vc(signedBytes, publicKey) → boolean`                | Verify a CBOR-encoded credential                                         |
-| `sign_protobuf_vc(unsignedBytes, privateKey) → Uint8Array`        | Sign a Protobuf-encoded credential                                       |
-| `verify_protobuf_vc(signedBytes, publicKey) → boolean`            | Verify a Protobuf-encoded credential                                     |
-| `normalize_object(input) → any`                                   | Remove `undefined`/`null` values from JS objects (useful before signing) |
+| `generate_keypair_for(algorithm) → KeyPair`                       | Generate a keypair for any algorithm label (`Ed25519`, `ML-DSA-44/65/87`) |
+| `sign(unsignedVC, privateKey) → VerifiableCredential`             | Sign a credential with Ed25519 (throws on error)                         |
+| `verify(signedVC, publicKey) → boolean`                           | Verify an Ed25519 signed credential                                      |
+| `sign_with_algorithm(unsignedVC, algorithm, privateKey) → VerifiableCredential` | Sign with any algorithm and raw key bytes              |
+| `verify_with_algorithm(signedVC, algorithm, publicKey) → boolean` | Verify with an explicit algorithm                                        |
+| `verify_auto(signedVC, publicKey) → boolean`                      | Verify, reading the algorithm from the proof's `cryptosuite`             |
+| `verify_with_schema_check(signedVC, publicKey, schema) → boolean` | Verify (Ed25519) with JSON Schema validation                             |
+| `sign_cbor_vc(unsignedBytes, privateKey) → Uint8Array`            | Sign a CBOR-encoded credential with Ed25519                              |
+| `verify_cbor_vc(signedBytes, publicKey) → boolean`                | Verify a CBOR-encoded Ed25519 credential                                 |
+| `sign_cbor_vc_with_algorithm(unsignedBytes, algorithm, privateKey) → Uint8Array` | Sign CBOR bytes with any algorithm                      |
+| `verify_cbor_vc_auto(signedBytes, publicKey) → boolean`           | Verify CBOR bytes, reading the algorithm from the proof                  |
+| `sign_protobuf_vc(unsignedBytes, privateKey) → Uint8Array`        | Sign a Protobuf-encoded credential with Ed25519                          |
+| `verify_protobuf_vc(signedBytes, publicKey) → boolean`            | Verify a Protobuf-encoded Ed25519 credential                             |
+| `sign_protobuf_vc_with_algorithm(unsignedBytes, algorithm, privateKey) → Uint8Array` | Sign Protobuf bytes with any algorithm              |
+| `verify_protobuf_vc_auto(signedBytes, publicKey) → boolean`       | Verify Protobuf bytes, reading the algorithm from the proof              |
+| `normalize_object(input) → any`                                   | Recursively strip `undefined` values from a JS object/array (`null` is preserved); useful before signing |
 
 TypeScript types live in [`verifiable_credential_toolkit.d.ts`](./verifiable_credential_toolkit.d.ts). Keys use branded types (`SigningKey` / `VerifyingKey`) so a public and private key can't be swapped at a call site — `KeyPair.signing_key()` / `.verifying_key()` return the right brand, and raw bytes are branded with an assertion (`bytes as SigningKey`).
 

--- a/examples/full_workflow.rs
+++ b/examples/full_workflow.rs
@@ -6,18 +6,19 @@
 
 use url::Url;
 use verifiable_credential_toolkit::{
-    generate_keypair, UnsignedVerifiableCredential, VerifiableCredential, VerifiablePresentation,
+    generate_keypair, Algorithm, UnsignedVerifiableCredential, VerifiableCredential,
+    VerifiablePresentation,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Step 1: Generate an Ed25519 keypair ─────────────────────────────
     println!("=== Step 1: Generate Ed25519 keypair ===\n");
-    let keypair = generate_keypair();
+    let keypair = generate_keypair(Algorithm::Ed25519);
     let signing_key = keypair.signing_key;
     let verifying_key = keypair.verifying_key;
     println!(
         "Public key (32 bytes): {:?}\n",
-        &verifying_key.to_bytes()[..8]
+        &verifying_key.as_bytes()[..8]
     );
 
     // ── Step 2: Define an unsigned Verifiable Credential ────────────────

--- a/examples/post_quantum.rs
+++ b/examples/post_quantum.rs
@@ -1,0 +1,151 @@
+//! Post-quantum (ML-DSA) signing across every algorithm, wire format, and verification
+//! path the toolkit exposes — the parts the Ed25519 `full_workflow` example doesn't reach.
+//!
+//! Demonstrates:
+//!   1. Generating raw ML-DSA key pairs and signing with `sign_with_algorithm`.
+//!   2. The three verification entry points: `verify_auto`, `verify_with_algorithm`.
+//!   3. Cross-format interop — a credential signed once verifies as JSON, CBOR, and
+//!      Protobuf, because the signature is over the format-independent JCS canonical form.
+//!   4. Signing/verifying directly on CBOR and Protobuf bytes via the `CredentialCodec` trait.
+//!   5. Injecting an externally-computed signature with `Proof::new_data_integrity` +
+//!      `VerifiableCredential::from_parts` (the HSM / out-of-process signer path).
+//!
+//! Run with:
+//!   cargo run --example post_quantum
+//!
+//! > ML-DSA cryptosuite identifiers here (`mldsa{44,65,87}-jcs-2025`) are a provisional
+//! > bilateral convention, not a finalized W3C standard — see the README.
+
+use multibase::Base;
+use verifiable_credential_toolkit::{
+    bindings::{cbor::Cbor, protobuf::Protobuf, CredentialCodec},
+    generate_keypair_bytes, generate_ml_dsa_keypair, Algorithm, Proof,
+    UnsignedVerifiableCredential, VerifiableCredential,
+};
+
+fn sample_credential() -> UnsignedVerifiableCredential {
+    serde_json::from_str(
+        r#"{
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "DeviceCertificate"],
+            "issuer": "https://example.com/issuers/pqc-authority",
+            "credentialSubject": {
+                "id": "urn:uuid:device-001",
+                "name": "Temperature Sensor Alpha",
+                "firmware": 42
+            }
+        }"#,
+    )
+    .expect("sample credential should parse")
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // ── Step 1: Every ML-DSA parameter set signs and verifies ───────────
+    println!("=== Step 1: Sign + verify with each ML-DSA parameter set ===\n");
+    for algorithm in [Algorithm::MlDsa44, Algorithm::MlDsa65, Algorithm::MlDsa87] {
+        let (private_key, public_key) = generate_keypair_bytes(algorithm);
+        let signed = sample_credential().sign_with_algorithm(algorithm, &private_key)?;
+
+        // `verify_auto` reads the algorithm from the proof's cryptosuite; the caller only
+        // needs the public key bytes.
+        signed.verify_auto(&public_key)?;
+        // `verify_with_algorithm` asserts the algorithm explicitly.
+        signed.verify_with_algorithm(algorithm, &public_key)?;
+
+        println!(
+            "  {:<9} private {:>4}B / public {:>4}B → cryptosuite {} ✓",
+            format!("{algorithm:?}"),
+            private_key.len(),
+            public_key.len(),
+            algorithm.cryptosuite(),
+        );
+    }
+
+    // ── Step 2: Typed keys (algorithm carried by the key) ───────────────
+    // `generate_ml_dsa_keypair` returns typed keys whose parameter set travels with the
+    // bytes; `sign_ml_dsa` / `verify_ml_dsa` then can't be called with a mismatched
+    // algorithm, and the verify rejects a proof whose cryptosuite names a different set.
+    println!("\n=== Step 2: Typed ML-DSA keys ===\n");
+    let typed = generate_ml_dsa_keypair(Algorithm::MlDsa65)?;
+    let typed_signed = sample_credential().sign_ml_dsa(&typed.signing_key)?;
+    typed_signed.verify_ml_dsa(&typed.verifying_key)?;
+    println!("  sign_ml_dsa / verify_ml_dsa round-trip ✓");
+    // A key for a different parameter set is refused (cryptosuite mismatch).
+    let wrong = generate_ml_dsa_keypair(Algorithm::MlDsa44)?;
+    println!(
+        "  an ML-DSA-44 key is rejected on this ML-DSA-65 proof: {}",
+        typed_signed.verify_ml_dsa(&wrong.verifying_key).is_err()
+    );
+
+    // ── Step 3: Hedged signing is non-deterministic ─────────────────────
+    println!("\n=== Step 3: Hedged (randomized) signing ===\n");
+    let (private_key, public_key) = generate_keypair_bytes(Algorithm::MlDsa65);
+    let first = sample_credential().sign_with_algorithm(Algorithm::MlDsa65, &private_key)?;
+    let second = sample_credential().sign_with_algorithm(Algorithm::MlDsa65, &private_key)?;
+    println!(
+        "  Two signatures over the same payload differ: {}",
+        first.proof.proof_value() != second.proof.proof_value()
+    );
+    println!("  …and both still verify: {}", {
+        first.verify_auto(&public_key).is_ok() && second.verify_auto(&public_key).is_ok()
+    });
+
+    // ── Step 4: One signature, three wire formats ───────────────────────
+    // The signature is over the JCS canonical form, so a credential signed via the JSON
+    // core verifies after being re-encoded as CBOR or Protobuf, with no re-signing.
+    println!("\n=== Step 4: Cross-format interop (sign once, verify everywhere) ===\n");
+    let signed = sample_credential().sign_with_algorithm(Algorithm::MlDsa65, &private_key)?;
+
+    let cbor = Cbor::encode_signed(&signed)?;
+    Cbor::verify_auto(&cbor, &public_key)?;
+    println!("  signed as JSON, verified as CBOR     ✓");
+
+    let protobuf = Protobuf::encode_signed(&signed)?;
+    Protobuf::verify_auto(&protobuf, &public_key)?;
+    println!("  signed as JSON, verified as Protobuf ✓");
+
+    // Sign on CBOR bytes, transcode to Protobuf, verify there.
+    let unsigned_cbor = Cbor::encode_unsigned(&sample_credential())?;
+    let signed_cbor = Cbor::sign(&unsigned_cbor, Algorithm::MlDsa65, &private_key)?;
+    let transcoded = Protobuf::encode_signed(&Cbor::decode_signed(&signed_cbor)?)?;
+    Protobuf::verify_auto(&transcoded, &public_key)?;
+    println!("  signed as CBOR, verified as Protobuf ✓");
+
+    // ── Step 5: External / out-of-process signer (e.g. an HSM) ──────────
+    // `signing_payload()` returns the exact JCS bytes to sign. Hand those to a
+    // FIPS-validated module / HSM over FFI, get back a raw signature, then wrap it in a
+    // DataIntegrityProof and attach it with `from_parts`.
+    println!("\n=== Step 5: Inject an externally-computed signature ===\n");
+    let unsigned = sample_credential();
+    let payload = unsigned.signing_payload()?;
+    println!(
+        "  signing_payload() → {} canonical bytes to hand to the HSM",
+        payload.len()
+    );
+
+    // Stand-in for the external signer: here we use the toolkit to produce a real ML-DSA
+    // signature, then decode its multibase proofValue back to the raw bytes such a signer
+    // would return. (A real HSM would compute these bytes itself, never touching this crate.)
+    let raw_signature = {
+        let (_, bytes) = multibase::decode(
+            unsigned
+                .clone()
+                .sign_with_algorithm(Algorithm::MlDsa65, &private_key)?
+                .proof
+                .proof_value(),
+        )?;
+        bytes
+    };
+
+    // Wrap the raw signature and assemble the signed credential by hand.
+    let proof = Proof::new_data_integrity(
+        Algorithm::MlDsa65.cryptosuite(),
+        multibase::encode(Base::Base58Btc, raw_signature),
+    );
+    let injected = VerifiableCredential::from_parts(unsigned, proof);
+    injected.verify_auto(&public_key)?;
+    println!("  externally-signed proof verifies ✓");
+
+    println!("\n=== Done! ===");
+    Ok(())
+}

--- a/examples/post_quantum.rs
+++ b/examples/post_quantum.rs
@@ -19,8 +19,8 @@
 use multibase::Base;
 use verifiable_credential_toolkit::{
     bindings::{cbor::Cbor, protobuf::Protobuf, CredentialCodec},
-    generate_keypair_bytes, generate_ml_dsa_keypair, Algorithm, Proof,
-    UnsignedVerifiableCredential, VerifiableCredential,
+    generate_keypair, generate_keypair_bytes, Algorithm, Proof, UnsignedVerifiableCredential,
+    VerifiableCredential,
 };
 
 fn sample_credential() -> UnsignedVerifiableCredential {
@@ -62,19 +62,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // ── Step 2: Typed keys (algorithm carried by the key) ───────────────
-    // `generate_ml_dsa_keypair` returns typed keys whose parameter set travels with the
-    // bytes; `sign_ml_dsa` / `verify_ml_dsa` then can't be called with a mismatched
-    // algorithm, and the verify rejects a proof whose cryptosuite names a different set.
+    // `generate_keypair` returns a typed key pair whose algorithm travels with the bytes —
+    // the same `sign` / `verify` used for Ed25519. The algorithm is read from the key, and
+    // `verify` rejects a proof whose cryptosuite names a different parameter set.
     println!("\n=== Step 2: Typed ML-DSA keys ===\n");
-    let typed = generate_ml_dsa_keypair(Algorithm::MlDsa65)?;
-    let typed_signed = sample_credential().sign_ml_dsa(&typed.signing_key)?;
-    typed_signed.verify_ml_dsa(&typed.verifying_key)?;
-    println!("  sign_ml_dsa / verify_ml_dsa round-trip ✓");
+    let typed = generate_keypair(Algorithm::MlDsa65);
+    let typed_signed = sample_credential().sign(&typed.signing_key)?;
+    typed_signed.verify(&typed.verifying_key)?;
+    println!("  sign / verify with typed keys round-trip ✓");
     // A key for a different parameter set is refused (cryptosuite mismatch).
-    let wrong = generate_ml_dsa_keypair(Algorithm::MlDsa44)?;
+    let wrong = generate_keypair(Algorithm::MlDsa44);
     println!(
         "  an ML-DSA-44 key is rejected on this ML-DSA-65 proof: {}",
-        typed_signed.verify_ml_dsa(&wrong.verifying_key).is_err()
+        typed_signed.verify(&wrong.verifying_key).is_err()
     );
 
     // ── Step 3: Hedged signing is non-deterministic ─────────────────────

--- a/examples/schema_validation.rs
+++ b/examples/schema_validation.rs
@@ -7,10 +7,12 @@
 //! Run with:
 //!   cargo run --example schema_validation
 
-use verifiable_credential_toolkit::{generate_keypair, SchemaSource, UnsignedVerifiableCredential};
+use verifiable_credential_toolkit::{
+    generate_keypair, Algorithm, SchemaSource, UnsignedVerifiableCredential,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let keypair = generate_keypair();
+    let keypair = generate_keypair(Algorithm::Ed25519);
     let signing_key = keypair.signing_key;
     let verifying_key = keypair.verifying_key;
 

--- a/src/bin/generate_keys.rs
+++ b/src/bin/generate_keys.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use verifiable_credential_toolkit::generate_keypair;
+use verifiable_credential_toolkit::{generate_keypair, Algorithm};
 
 /// CLI for generating Ed25519 key pairs
 #[derive(Parser)]
@@ -17,9 +17,9 @@ struct Cli {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
-    let keypair = generate_keypair();
-    let signing_key = keypair.signing_key.to_bytes();
-    let verifying_key = keypair.verifying_key.to_bytes();
+    let keypair = generate_keypair(Algorithm::Ed25519);
+    let signing_key = keypair.signing_key.as_bytes();
+    let verifying_key = keypair.verifying_key.as_bytes();
 
     // Get the current time for the file names
     let start = SystemTime::now();
@@ -29,13 +29,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Save the public key (32 bytes)
     let pub_path = cli.output.join(format!("{datetime}.pub"));
     let mut pub_file = File::create(&pub_path)?;
-    pub_file.write_all(&verifying_key)?;
+    pub_file.write_all(verifying_key)?;
     println!("Public key saved to: {}", pub_path.display());
 
     // Save the private key (32 bytes)
     let priv_path = cli.output.join(format!("{datetime}.priv"));
     let mut priv_file = File::create(&priv_path)?;
-    priv_file.write_all(&signing_key)?;
+    priv_file.write_all(signing_key)?;
     println!("Private key saved to: {}", priv_path.display());
 
     Ok(())

--- a/src/bin/vc_signer.rs
+++ b/src/bin/vc_signer.rs
@@ -2,7 +2,8 @@ use clap::{Parser, Subcommand};
 use std::fs;
 use std::path::PathBuf;
 use verifiable_credential_toolkit::{
-    SchemaSource, SigningKey, UnsignedVerifiableCredential, VerifiableCredential, VerifyingKey,
+    Algorithm, SchemaSource, SigningKey, UnsignedVerifiableCredential, VerifiableCredential,
+    VerifyingKey,
 };
 
 #[derive(Parser)]
@@ -79,8 +80,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             };
 
-            // Read the private key
-            let signing_key = SigningKey::from_bytes(&fs::read(key)?)?;
+            // Read the private key (raw 32-byte Ed25519 seed)
+            let signing_key = SigningKey::new(Algorithm::Ed25519, &fs::read(key)?)?;
 
             // Resolve the schema source from the CLI options. An inline schema
             // file is loaded here so it outlives the borrow held by SchemaSource.
@@ -135,8 +136,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             };
 
-            // Read the public key
-            let verifying_key = VerifyingKey::from_bytes(&fs::read(key)?)?;
+            // Read the public key (raw 32-byte Ed25519 key)
+            let verifying_key = VerifyingKey::new(Algorithm::Ed25519, &fs::read(key)?)?;
 
             // Verify the VC
             let result = signed_vc.verify(&verifying_key);

--- a/src/bindings/cbor.rs
+++ b/src/bindings/cbor.rs
@@ -1,7 +1,10 @@
-use crate::bindings::{sign_via, verify_via, CredentialCodec};
+use crate::bindings::{
+    sign_via, sign_with_algorithm_via, verify_auto_via, verify_via, verify_with_algorithm_via,
+    CredentialCodec,
+};
 use crate::UnsignedVerifiableCredential;
 use crate::VerifiableCredential;
-use crate::{SigningKey, VcError, VerifyingKey};
+use crate::{Algorithm, SigningKey, VcError, VerifyingKey};
 use c2pa_cbor::{from_slice, to_vec};
 
 /// The CBOR serialization format.
@@ -53,6 +56,31 @@ pub fn sign_cbor_vc(unsigned_vc_cbor: &[u8], signing_key: &SigningKey) -> Result
 /// Convenience wrapper: decode signed VC cbor and verify its signature.
 pub fn verify_cbor_vc(signed_vc_cbor: &[u8], verifying_key: &VerifyingKey) -> Result<(), VcError> {
     verify_via::<Cbor>(signed_vc_cbor, verifying_key)
+}
+
+/// Decode unsigned VC cbor, sign with the given [Algorithm] + raw private key, re-encode
+/// as cbor. Supports every cryptosuite (Ed25519, ML-DSA-44/65/87).
+pub fn sign_cbor_vc_with_algorithm(
+    unsigned_vc_cbor: &[u8],
+    algorithm: Algorithm,
+    private_key: &[u8],
+) -> Result<Vec<u8>, VcError> {
+    sign_with_algorithm_via::<Cbor>(unsigned_vc_cbor, algorithm, private_key)
+}
+
+/// Decode signed VC cbor and verify with an explicit [Algorithm] + raw public key.
+pub fn verify_cbor_vc_with_algorithm(
+    signed_vc_cbor: &[u8],
+    algorithm: Algorithm,
+    public_key: &[u8],
+) -> Result<(), VcError> {
+    verify_with_algorithm_via::<Cbor>(signed_vc_cbor, algorithm, public_key)
+}
+
+/// Decode signed VC cbor and verify, reading the algorithm from the proof's
+/// `cryptosuite`. The caller supplies only the raw public key bytes.
+pub fn verify_cbor_vc_auto(signed_vc_cbor: &[u8], public_key: &[u8]) -> Result<(), VcError> {
+    verify_auto_via::<Cbor>(signed_vc_cbor, public_key)
 }
 
 #[cfg(test)]

--- a/src/bindings/cbor.rs
+++ b/src/bindings/cbor.rs
@@ -1,92 +1,37 @@
-use crate::bindings::{
-    sign_via, sign_with_algorithm_via, verify_auto_via, verify_via, verify_with_algorithm_via,
-    CredentialCodec,
-};
+use crate::bindings::CredentialCodec;
 use crate::UnsignedVerifiableCredential;
+use crate::VcError;
 use crate::VerifiableCredential;
-use crate::{Algorithm, SigningKey, VcError, VerifyingKey};
 use c2pa_cbor::{from_slice, to_vec};
 
 /// The CBOR serialization format.
+///
+/// Sign and verify through the [CredentialCodec] methods: `Cbor::sign(bytes, alg, sk)`,
+/// `Cbor::verify_auto(bytes, pk)`, etc.
 pub struct Cbor;
 
 impl CredentialCodec for Cbor {
     fn decode_unsigned(bytes: &[u8]) -> Result<UnsignedVerifiableCredential, VcError> {
-        decode_unsigned_vc_from_cbor(bytes).map_err(|e| VcError::Codec(Box::new(e)))
+        from_slice(bytes).map_err(|e| VcError::Codec(Box::new(e)))
     }
 
     fn decode_signed(bytes: &[u8]) -> Result<VerifiableCredential, VcError> {
-        decode_signed_vc_from_cbor(bytes).map_err(|e| VcError::Codec(Box::new(e)))
+        from_slice(bytes).map_err(|e| VcError::Codec(Box::new(e)))
+    }
+
+    fn encode_unsigned(vc: &UnsignedVerifiableCredential) -> Result<Vec<u8>, VcError> {
+        to_vec(vc).map_err(|e| VcError::Codec(Box::new(e)))
     }
 
     fn encode_signed(vc: &VerifiableCredential) -> Result<Vec<u8>, VcError> {
-        encode_signed_vc_to_cbor(vc).map_err(|e| VcError::Codec(Box::new(e)))
+        to_vec(vc).map_err(|e| VcError::Codec(Box::new(e)))
     }
-}
-
-/// Decode cbor bytes into the existing unsigned VC Rust struct.
-pub fn decode_unsigned_vc_from_cbor(
-    bytes: &[u8],
-) -> Result<UnsignedVerifiableCredential, c2pa_cbor::Error> {
-    from_slice(bytes)
-}
-
-/// Decode cbor bytes into the existing signed VC Rust struct.
-pub fn decode_signed_vc_from_cbor(bytes: &[u8]) -> Result<VerifiableCredential, c2pa_cbor::Error> {
-    from_slice(bytes)
-}
-
-/// Encode an unsigned VC Rust struct into cbor bytes.
-pub fn encode_unsigned_vc_to_cbor(
-    vc: &UnsignedVerifiableCredential,
-) -> Result<Vec<u8>, c2pa_cbor::Error> {
-    to_vec(&vc)
-}
-
-/// Encode the existing signed VC Rust struct into cbor bytes.
-pub fn encode_signed_vc_to_cbor(vc: &VerifiableCredential) -> Result<Vec<u8>, c2pa_cbor::Error> {
-    to_vec(&vc)
-}
-
-/// Convenience wrapper: decode unsigned VC cbor, sign it, and re-encode as cbor.
-pub fn sign_cbor_vc(unsigned_vc_cbor: &[u8], signing_key: &SigningKey) -> Result<Vec<u8>, VcError> {
-    sign_via::<Cbor>(unsigned_vc_cbor, signing_key)
-}
-
-/// Convenience wrapper: decode signed VC cbor and verify its signature.
-pub fn verify_cbor_vc(signed_vc_cbor: &[u8], verifying_key: &VerifyingKey) -> Result<(), VcError> {
-    verify_via::<Cbor>(signed_vc_cbor, verifying_key)
-}
-
-/// Decode unsigned VC cbor, sign with the given [Algorithm] + raw private key, re-encode
-/// as cbor. Supports every cryptosuite (Ed25519, ML-DSA-44/65/87).
-pub fn sign_cbor_vc_with_algorithm(
-    unsigned_vc_cbor: &[u8],
-    algorithm: Algorithm,
-    private_key: &[u8],
-) -> Result<Vec<u8>, VcError> {
-    sign_with_algorithm_via::<Cbor>(unsigned_vc_cbor, algorithm, private_key)
-}
-
-/// Decode signed VC cbor and verify with an explicit [Algorithm] + raw public key.
-pub fn verify_cbor_vc_with_algorithm(
-    signed_vc_cbor: &[u8],
-    algorithm: Algorithm,
-    public_key: &[u8],
-) -> Result<(), VcError> {
-    verify_with_algorithm_via::<Cbor>(signed_vc_cbor, algorithm, public_key)
-}
-
-/// Decode signed VC cbor and verify, reading the algorithm from the proof's
-/// `cryptosuite`. The caller supplies only the raw public key bytes.
-pub fn verify_cbor_vc_auto(signed_vc_cbor: &[u8], public_key: &[u8]) -> Result<(), VcError> {
-    verify_auto_via::<Cbor>(signed_vc_cbor, public_key)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::generate_keypair;
+    use crate::{generate_keypair_bytes, Algorithm};
     use serde_json::json;
 
     fn sample_unsigned_vc() -> UnsignedVerifiableCredential {
@@ -111,13 +56,13 @@ mod tests {
 
     #[test]
     fn test_sign_and_verify_roundtrip() {
-        let keypair = generate_keypair();
+        let (private_key, public_key) = generate_keypair_bytes(Algorithm::Ed25519);
 
-        let unsigned_vc = sample_unsigned_vc();
+        let cbor = Cbor::encode_unsigned(&sample_unsigned_vc()).expect("CBOR encode failed");
+        let signed_bytes =
+            Cbor::sign(&cbor, Algorithm::Ed25519, &private_key).expect("CBOR signing failed");
 
-        let cbor: Vec<u8> = to_vec(&unsigned_vc).expect("failed to serialize unsigned VC to CBOR");
-        let signed_bytes = sign_cbor_vc(&cbor, &keypair.signing_key).expect("CBOR signing failed");
-
-        verify_cbor_vc(&signed_bytes, &keypair.verifying_key).expect("cbor verification failed");
+        Cbor::verify(&signed_bytes, Algorithm::Ed25519, &public_key)
+            .expect("CBOR verification failed");
     }
 }

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -5,7 +5,8 @@
 //! duplicated per format.
 
 use crate::{
-    SigningKey, UnsignedVerifiableCredential, VcError, VerifiableCredential, VerifyingKey,
+    Algorithm, SigningKey, UnsignedVerifiableCredential, VcError, VerifiableCredential,
+    VerifyingKey,
 };
 
 pub mod cbor;
@@ -43,4 +44,38 @@ pub fn verify_via<C: CredentialCodec>(
     verifying_key: &VerifyingKey,
 ) -> Result<(), VcError> {
     C::decode_signed(signed_bytes)?.verify(verifying_key)
+}
+
+/// Decode an unsigned credential in format `C`, sign it with the given [Algorithm] and
+/// raw private key, and re-encode the signed credential in the same format. Works for
+/// every supported cryptosuite (Ed25519, ML-DSA-44/65/87).
+pub fn sign_with_algorithm_via<C: CredentialCodec>(
+    unsigned_bytes: &[u8],
+    algorithm: Algorithm,
+    private_key: &[u8],
+) -> Result<Vec<u8>, VcError> {
+    let signed = C::decode_unsigned(unsigned_bytes)?.sign_with_algorithm(algorithm, private_key)?;
+    C::encode_signed(&signed)
+}
+
+/// Decode a signed credential in format `C` and verify it with an explicit [Algorithm]
+/// and raw public key.
+pub fn verify_with_algorithm_via<C: CredentialCodec>(
+    signed_bytes: &[u8],
+    algorithm: Algorithm,
+    public_key: &[u8],
+) -> Result<(), VcError> {
+    C::decode_signed(signed_bytes)?.verify_with_algorithm(algorithm, public_key)
+}
+
+/// Decode a signed credential in format `C` and verify it, reading the algorithm from the
+/// proof's `cryptosuite`. The caller supplies only the raw public key bytes. This is the
+/// cross-format, cross-algorithm verification entry point: a credential signed in any
+/// format with any supported cryptosuite verifies here, because the signature is over the
+/// format-independent JCS canonical form.
+pub fn verify_auto_via<C: CredentialCodec>(
+    signed_bytes: &[u8],
+    public_key: &[u8],
+) -> Result<(), VcError> {
+    C::decode_signed(signed_bytes)?.verify_auto(public_key)
 }

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -1,22 +1,32 @@
 //! Serialization-format bindings for verifiable credentials.
 //!
-//! Each wire format (CBOR, Protobuf, …) implements [CredentialCodec], which lets the
-//! sign/verify pipelines be written once, generically over the format, rather than
-//! duplicated per format.
+//! Each wire format (CBOR, Protobuf, …) implements [CredentialCodec] by supplying only
+//! the four bytes↔domain conversions. The sign / verify / verify_auto pipeline is provided
+//! once as default methods on the trait, so a format gets the full signing API for free and
+//! the public surface stays "one codec type per format" rather than a bank of free
+//! functions per format.
 
-use crate::{
-    Algorithm, SigningKey, UnsignedVerifiableCredential, VcError, VerifiableCredential,
-    VerifyingKey,
-};
+use crate::{Algorithm, UnsignedVerifiableCredential, VcError, VerifiableCredential};
 
 pub mod cbor;
 pub mod protobuf;
 
 /// A serialization format that can decode and encode verifiable credentials.
 ///
-/// Implementors only describe how to move between bytes and the domain types; the
-/// shared [sign_via] / [verify_via] pipelines provide the actual signing and
-/// verification on top.
+/// Implementors describe only how to move between bytes and the domain types; the default
+/// [sign](CredentialCodec::sign) / [verify](CredentialCodec::verify) /
+/// [verify_auto](CredentialCodec::verify_auto) methods build the signing pipeline on top.
+/// Because every signature is taken over the format-independent JCS canonical form, a
+/// credential signed in one format with any supported cryptosuite verifies in any other.
+///
+/// ```no_run
+/// # use verifiable_credential_toolkit::{Algorithm, bindings::{CredentialCodec, cbor::Cbor}};
+/// # fn demo(unsigned_cbor: &[u8], sk: &[u8], pk: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+/// let signed = Cbor::sign(unsigned_cbor, Algorithm::MlDsa65, sk)?;
+/// Cbor::verify_auto(&signed, pk)?;
+/// # Ok(())
+/// # }
+/// ```
 pub trait CredentialCodec {
     /// Decode an unsigned credential from this format's bytes.
     fn decode_unsigned(bytes: &[u8]) -> Result<UnsignedVerifiableCredential, VcError>;
@@ -24,58 +34,36 @@ pub trait CredentialCodec {
     /// Decode a signed credential from this format's bytes.
     fn decode_signed(bytes: &[u8]) -> Result<VerifiableCredential, VcError>;
 
+    /// Encode an unsigned credential into this format's bytes.
+    fn encode_unsigned(vc: &UnsignedVerifiableCredential) -> Result<Vec<u8>, VcError>;
+
     /// Encode a signed credential into this format's bytes.
     fn encode_signed(vc: &VerifiableCredential) -> Result<Vec<u8>, VcError>;
-}
 
-/// Decode an unsigned credential in format `C`, sign it, and re-encode the signed
-/// credential in the same format.
-pub fn sign_via<C: CredentialCodec>(
-    unsigned_bytes: &[u8],
-    signing_key: &SigningKey,
-) -> Result<Vec<u8>, VcError> {
-    let signed = C::decode_unsigned(unsigned_bytes)?.sign(signing_key)?;
-    C::encode_signed(&signed)
-}
+    /// Decode an unsigned credential, sign it with the given [Algorithm] and raw private
+    /// key, and re-encode the signed credential in the same format. Works for every
+    /// supported cryptosuite (Ed25519, ML-DSA-44/65/87).
+    fn sign(
+        unsigned_bytes: &[u8],
+        algorithm: Algorithm,
+        private_key: &[u8],
+    ) -> Result<Vec<u8>, VcError> {
+        let signed =
+            Self::decode_unsigned(unsigned_bytes)?.sign_with_algorithm(algorithm, private_key)?;
+        Self::encode_signed(&signed)
+    }
 
-/// Decode a signed credential in format `C` and verify its signature.
-pub fn verify_via<C: CredentialCodec>(
-    signed_bytes: &[u8],
-    verifying_key: &VerifyingKey,
-) -> Result<(), VcError> {
-    C::decode_signed(signed_bytes)?.verify(verifying_key)
-}
+    /// Decode a signed credential and verify it with an explicit [Algorithm] and raw public
+    /// key. Does not require the proof's `cryptosuite` to match (the caller asserts the
+    /// algorithm).
+    fn verify(signed_bytes: &[u8], algorithm: Algorithm, public_key: &[u8]) -> Result<(), VcError> {
+        Self::decode_signed(signed_bytes)?.verify_with_algorithm(algorithm, public_key)
+    }
 
-/// Decode an unsigned credential in format `C`, sign it with the given [Algorithm] and
-/// raw private key, and re-encode the signed credential in the same format. Works for
-/// every supported cryptosuite (Ed25519, ML-DSA-44/65/87).
-pub fn sign_with_algorithm_via<C: CredentialCodec>(
-    unsigned_bytes: &[u8],
-    algorithm: Algorithm,
-    private_key: &[u8],
-) -> Result<Vec<u8>, VcError> {
-    let signed = C::decode_unsigned(unsigned_bytes)?.sign_with_algorithm(algorithm, private_key)?;
-    C::encode_signed(&signed)
-}
-
-/// Decode a signed credential in format `C` and verify it with an explicit [Algorithm]
-/// and raw public key.
-pub fn verify_with_algorithm_via<C: CredentialCodec>(
-    signed_bytes: &[u8],
-    algorithm: Algorithm,
-    public_key: &[u8],
-) -> Result<(), VcError> {
-    C::decode_signed(signed_bytes)?.verify_with_algorithm(algorithm, public_key)
-}
-
-/// Decode a signed credential in format `C` and verify it, reading the algorithm from the
-/// proof's `cryptosuite`. The caller supplies only the raw public key bytes. This is the
-/// cross-format, cross-algorithm verification entry point: a credential signed in any
-/// format with any supported cryptosuite verifies here, because the signature is over the
-/// format-independent JCS canonical form.
-pub fn verify_auto_via<C: CredentialCodec>(
-    signed_bytes: &[u8],
-    public_key: &[u8],
-) -> Result<(), VcError> {
-    C::decode_signed(signed_bytes)?.verify_auto(public_key)
+    /// Decode a signed credential and verify it, reading the algorithm from the proof's
+    /// `cryptosuite`. The caller supplies only the raw public key bytes. Returns
+    /// [VcError::UnsupportedCryptosuite] if the proof names a suite this library can't verify.
+    fn verify_auto(signed_bytes: &[u8], public_key: &[u8]) -> Result<(), VcError> {
+        Self::decode_signed(signed_bytes)?.verify_auto(public_key)
+    }
 }

--- a/src/bindings/protobuf.rs
+++ b/src/bindings/protobuf.rs
@@ -1,21 +1,15 @@
-use crate::bindings::{
-    sign_via, sign_with_algorithm_via, verify_auto_via, verify_via, verify_with_algorithm_via,
-    CredentialCodec,
-};
+use crate::bindings::CredentialCodec;
 use crate::proto_schemas::vc::UnsignedVerifiableCredential as ProtobufUnsignedVerifiableCredential;
 use crate::proto_schemas::vc::VerifiableCredential as ProtobufVerifiableCredential;
 use crate::UnsignedVerifiableCredential;
+use crate::VcError;
 use crate::VerifiableCredential;
-use crate::{Algorithm, SigningKey, VcError, VerifyingKey};
-use protobuf::Message;
 use protobuf_json_mapping::{
     parse_from_str as json_to_protobuf, print_to_string as protobuf_to_json,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
-
-pub type ProtoResult<T> = Result<T, Box<dyn std::error::Error>>;
 
 /// `json_name` of every field whose JSON shape is open (arbitrary objects or
 /// string-or-object polymorphism). On the wire these are typed `string` fields holding
@@ -51,6 +45,10 @@ impl CredentialCodec for Protobuf {
 
     fn decode_signed(bytes: &[u8]) -> Result<VerifiableCredential, VcError> {
         decode_from_protobuf::<ProtobufVerifiableCredential, _>(bytes)
+    }
+
+    fn encode_unsigned(vc: &UnsignedVerifiableCredential) -> Result<Vec<u8>, VcError> {
+        encode_to_protobuf::<_, ProtobufUnsignedVerifiableCredential>(vc)
     }
 
     fn encode_signed(vc: &VerifiableCredential) -> Result<Vec<u8>, VcError> {
@@ -162,78 +160,10 @@ where
     protobuf.write_to_bytes().map_err(codec_err)
 }
 
-/// Decode protobuf bytes into the protobuf-generated unsigned VC struct.
-pub fn decode_unsigned_vc_from_protobuf(
-    bytes: &[u8],
-) -> ProtoResult<ProtobufUnsignedVerifiableCredential> {
-    Ok(ProtobufUnsignedVerifiableCredential::parse_from_bytes(
-        bytes,
-    )?)
-}
-
-/// Decode protobuf bytes into the protobuf-generated signed VC struct.
-pub fn decode_signed_vc_from_protobuf(bytes: &[u8]) -> ProtoResult<ProtobufVerifiableCredential> {
-    Ok(ProtobufVerifiableCredential::parse_from_bytes(bytes)?)
-}
-
-/// Encode an unsigned VC Rust struct into protobuf bytes.
-pub fn encode_unsigned_vc_to_protobuf(vc: &UnsignedVerifiableCredential) -> ProtoResult<Vec<u8>> {
-    Ok(encode_to_protobuf::<_, ProtobufUnsignedVerifiableCredential>(vc)?)
-}
-
-/// Encode the existing signed VC Rust struct into protobuf bytes.
-pub fn encode_signed_vc_to_protobuf(vc: &VerifiableCredential) -> ProtoResult<Vec<u8>> {
-    Ok(encode_to_protobuf::<_, ProtobufVerifiableCredential>(vc)?)
-}
-
-/// Convenience wrapper: decode unsigned VC protobuf, sign it, and re-encode as protobuf.
-pub fn sign_protobuf_vc(
-    unsigned_vc_protobuf: &[u8],
-    signing_key: &SigningKey,
-) -> Result<Vec<u8>, VcError> {
-    sign_via::<Protobuf>(unsigned_vc_protobuf, signing_key)
-}
-
-/// Convenience wrapper: decode signed VC protobuf and verify its signature.
-pub fn verify_protobuf_vc(
-    signed_vc_protobuf: &[u8],
-    verifying_key: &VerifyingKey,
-) -> Result<(), VcError> {
-    verify_via::<Protobuf>(signed_vc_protobuf, verifying_key)
-}
-
-/// Decode unsigned VC protobuf, sign with the given [Algorithm] + raw private key,
-/// re-encode as protobuf. Supports every cryptosuite (Ed25519, ML-DSA-44/65/87).
-pub fn sign_protobuf_vc_with_algorithm(
-    unsigned_vc_protobuf: &[u8],
-    algorithm: Algorithm,
-    private_key: &[u8],
-) -> Result<Vec<u8>, VcError> {
-    sign_with_algorithm_via::<Protobuf>(unsigned_vc_protobuf, algorithm, private_key)
-}
-
-/// Decode signed VC protobuf and verify with an explicit [Algorithm] + raw public key.
-pub fn verify_protobuf_vc_with_algorithm(
-    signed_vc_protobuf: &[u8],
-    algorithm: Algorithm,
-    public_key: &[u8],
-) -> Result<(), VcError> {
-    verify_with_algorithm_via::<Protobuf>(signed_vc_protobuf, algorithm, public_key)
-}
-
-/// Decode signed VC protobuf and verify, reading the algorithm from the proof's
-/// `cryptosuite`. The caller supplies only the raw public key bytes.
-pub fn verify_protobuf_vc_auto(
-    signed_vc_protobuf: &[u8],
-    public_key: &[u8],
-) -> Result<(), VcError> {
-    verify_auto_via::<Protobuf>(signed_vc_protobuf, public_key)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::generate_keypair;
+    use crate::{generate_keypair_bytes, Algorithm};
     use serde_json::json;
 
     fn sample_unsigned_vc() -> UnsignedVerifiableCredential {
@@ -258,16 +188,15 @@ mod tests {
 
     #[test]
     fn test_sign_and_verify_roundtrip() {
-        let keypair = generate_keypair();
+        let (private_key, public_key) = generate_keypair_bytes(Algorithm::Ed25519);
 
-        let unsigned_vc = sample_unsigned_vc();
         let unsigned_bytes =
-            encode_unsigned_vc_to_protobuf(&unsigned_vc).expect("unsigned encode failed");
+            Protobuf::encode_unsigned(&sample_unsigned_vc()).expect("unsigned encode failed");
 
-        let signed_bytes = sign_protobuf_vc(&unsigned_bytes, &keypair.signing_key)
+        let signed_bytes = Protobuf::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key)
             .expect("protobuf signing failed");
 
-        verify_protobuf_vc(&signed_bytes, &keypair.verifying_key)
+        Protobuf::verify(&signed_bytes, Algorithm::Ed25519, &public_key)
             .expect("protobuf verification failed");
     }
 
@@ -276,7 +205,7 @@ mod tests {
     /// arrays for the typed `repeated` protobuf fields.
     #[test]
     fn test_single_element_oneormany_roundtrip() {
-        let keypair = generate_keypair();
+        let (private_key, public_key) = generate_keypair_bytes(Algorithm::Ed25519);
 
         let unsigned_vc: UnsignedVerifiableCredential = serde_json::from_value(json!({
           "@context": ["https://www.w3.org/ns/credentials/v2"],
@@ -288,11 +217,11 @@ mod tests {
         .expect("sample unsigned VC should deserialize");
 
         let unsigned_bytes =
-            encode_unsigned_vc_to_protobuf(&unsigned_vc).expect("unsigned encode failed");
-        let signed_bytes = sign_protobuf_vc(&unsigned_bytes, &keypair.signing_key)
+            Protobuf::encode_unsigned(&unsigned_vc).expect("unsigned encode failed");
+        let signed_bytes = Protobuf::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key)
             .expect("protobuf signing failed");
 
-        verify_protobuf_vc(&signed_bytes, &keypair.verifying_key)
+        Protobuf::verify(&signed_bytes, Algorithm::Ed25519, &public_key)
             .expect("protobuf verification failed");
 
         // The decoded credential must preserve the single-element shapes.

--- a/src/bindings/protobuf.rs
+++ b/src/bindings/protobuf.rs
@@ -1,9 +1,12 @@
-use crate::bindings::{sign_via, verify_via, CredentialCodec};
+use crate::bindings::{
+    sign_via, sign_with_algorithm_via, verify_auto_via, verify_via, verify_with_algorithm_via,
+    CredentialCodec,
+};
 use crate::proto_schemas::vc::UnsignedVerifiableCredential as ProtobufUnsignedVerifiableCredential;
 use crate::proto_schemas::vc::VerifiableCredential as ProtobufVerifiableCredential;
 use crate::UnsignedVerifiableCredential;
 use crate::VerifiableCredential;
-use crate::{SigningKey, VcError, VerifyingKey};
+use crate::{Algorithm, SigningKey, VcError, VerifyingKey};
 use protobuf::Message;
 use protobuf_json_mapping::{
     parse_from_str as json_to_protobuf, print_to_string as protobuf_to_json,
@@ -197,6 +200,34 @@ pub fn verify_protobuf_vc(
     verifying_key: &VerifyingKey,
 ) -> Result<(), VcError> {
     verify_via::<Protobuf>(signed_vc_protobuf, verifying_key)
+}
+
+/// Decode unsigned VC protobuf, sign with the given [Algorithm] + raw private key,
+/// re-encode as protobuf. Supports every cryptosuite (Ed25519, ML-DSA-44/65/87).
+pub fn sign_protobuf_vc_with_algorithm(
+    unsigned_vc_protobuf: &[u8],
+    algorithm: Algorithm,
+    private_key: &[u8],
+) -> Result<Vec<u8>, VcError> {
+    sign_with_algorithm_via::<Protobuf>(unsigned_vc_protobuf, algorithm, private_key)
+}
+
+/// Decode signed VC protobuf and verify with an explicit [Algorithm] + raw public key.
+pub fn verify_protobuf_vc_with_algorithm(
+    signed_vc_protobuf: &[u8],
+    algorithm: Algorithm,
+    public_key: &[u8],
+) -> Result<(), VcError> {
+    verify_with_algorithm_via::<Protobuf>(signed_vc_protobuf, algorithm, public_key)
+}
+
+/// Decode signed VC protobuf and verify, reading the algorithm from the proof's
+/// `cryptosuite`. The caller supplies only the raw public key bytes.
+pub fn verify_protobuf_vc_auto(
+    signed_vc_protobuf: &[u8],
+    public_key: &[u8],
+) -> Result<(), VcError> {
+    verify_auto_via::<Protobuf>(signed_vc_protobuf, public_key)
 }
 
 #[cfg(test)]

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,383 @@
+//! Signature algorithms and keys.
+//!
+//! The toolkit signs and verifies credentials with one of several algorithms — Ed25519
+//! and the three ML-DSA (FIPS 204) parameter sets — behind a single model. A key is an
+//! [Algorithm] tag plus raw bytes ([SigningKey] / [VerifyingKey]); ML-DSA is not
+//! special-cased, it is just another [Algorithm]. The credential `sign` / `verify`
+//! methods read the algorithm from the key, so the same call works for any algorithm.
+//!
+//! Internally each algorithm is a [SignatureScheme] implementation selected by
+//! [Algorithm::scheme]; that trait is the seam where a FIPS-validated / HSM backend can be
+//! dropped in as one more implementation without touching the public API.
+
+use crate::VcError;
+use ed25519_dalek::{
+    Signature, Signer, SigningKey as DalekSigningKey, Verifier, VerifyingKey as DalekVerifyingKey,
+};
+use std::fmt;
+use std::marker::PhantomData;
+
+/// A signature algorithm the toolkit can sign and verify with.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Algorithm {
+    /// Ed25519 (EdDSA). 32-byte keys, `eddsa-jcs-2022` cryptosuite.
+    Ed25519,
+    /// ML-DSA-44 (FIPS 204, security category 2).
+    MlDsa44,
+    /// ML-DSA-65 (FIPS 204, security category 3).
+    MlDsa65,
+    /// ML-DSA-87 (FIPS 204, security category 5).
+    MlDsa87,
+}
+
+impl Algorithm {
+    /// The `cryptosuite` identifier written into a [Proof](crate::Proof) signed with this
+    /// algorithm.
+    ///
+    /// Ed25519 uses the standardized `eddsa-jcs-2022`. The ML-DSA identifiers are
+    /// **provisional and bilateral**: the W3C `vc-di-mldsa` cryptosuite is still a Working
+    /// Draft with no finalized identifier, so these strings are a private convention that
+    /// signing and verifying parties must agree on out of band (see the README). All use
+    /// JCS (RFC 8785) canonicalization.
+    pub fn cryptosuite(self) -> &'static str {
+        match self {
+            Algorithm::Ed25519 => "eddsa-jcs-2022",
+            Algorithm::MlDsa44 => "mldsa44-jcs-2025",
+            Algorithm::MlDsa65 => "mldsa65-jcs-2025",
+            Algorithm::MlDsa87 => "mldsa87-jcs-2025",
+        }
+    }
+
+    /// Map a proof `cryptosuite` identifier back to an [Algorithm], or `None` if the
+    /// identifier is not one this library implements.
+    pub fn from_cryptosuite(cryptosuite: &str) -> Option<Self> {
+        match cryptosuite {
+            "eddsa-jcs-2022" => Some(Algorithm::Ed25519),
+            "mldsa44-jcs-2025" => Some(Algorithm::MlDsa44),
+            "mldsa65-jcs-2025" => Some(Algorithm::MlDsa65),
+            "mldsa87-jcs-2025" => Some(Algorithm::MlDsa87),
+            _ => None,
+        }
+    }
+
+    /// The raw key lengths `(private, public)` in bytes for this algorithm. For Ed25519
+    /// both are 32; for ML-DSA these are the FIPS 204 sizes (and are pinned by the
+    /// `keypair_byte_lengths_match_wire_contract` test). Used to length-check keys at
+    /// construction.
+    fn key_lengths(self) -> (usize, usize) {
+        match self {
+            Algorithm::Ed25519 => (32, 32),
+            Algorithm::MlDsa44 => (2560, 1312),
+            Algorithm::MlDsa65 => (4032, 1952),
+            Algorithm::MlDsa87 => (4896, 2592),
+        }
+    }
+
+    /// The single dispatch point from the runtime [Algorithm] tag to the compile-time
+    /// [SignatureScheme] that implements it. Every sign / verify / keygen call routes
+    /// through here, so this is the only place that enumerates the variants — adding an
+    /// algorithm means adding one arm here plus one trait impl.
+    fn scheme(self) -> Box<dyn SignatureScheme> {
+        match self {
+            Algorithm::Ed25519 => Box::new(Ed25519Scheme),
+            Algorithm::MlDsa44 => Box::new(MlDsaScheme::<ml_dsa::MlDsa44>(PhantomData)),
+            Algorithm::MlDsa65 => Box::new(MlDsaScheme::<ml_dsa::MlDsa65>(PhantomData)),
+            Algorithm::MlDsa87 => Box::new(MlDsaScheme::<ml_dsa::MlDsa87>(PhantomData)),
+        }
+    }
+}
+
+/// Sign `message` with `algorithm` and a raw private key of the matching length, returning
+/// the raw signature bytes. The credential-level wrapping (JCS payload, multibase, the
+/// `DataIntegrityProof`) lives in the crate root.
+pub(crate) fn sign_bytes(
+    algorithm: Algorithm,
+    private_key: &[u8],
+    message: &[u8],
+) -> Result<Vec<u8>, VcError> {
+    algorithm.scheme().sign(private_key, message)
+}
+
+/// Verify a raw `signature` over `message` with `algorithm` and a raw public key.
+pub(crate) fn verify_bytes(
+    algorithm: Algorithm,
+    public_key: &[u8],
+    message: &[u8],
+    signature: &[u8],
+) -> Result<(), VcError> {
+    algorithm.scheme().verify(public_key, message, signature)
+}
+
+/// The per-algorithm signing operations, behind one interface. Implemented by a
+/// zero-sized marker per scheme ([Ed25519Scheme], [MlDsaScheme]) and selected at runtime
+/// by [Algorithm::scheme]. Keeping this private means the public API stays the [Algorithm]
+/// enum and the key types; this trait only removes the duplicated `match` arms and
+/// provides the seam where a FIPS-validated / HSM backend can be dropped in as one extra
+/// impl.
+trait SignatureScheme {
+    /// Sign `message` with a raw private key of this scheme's expected length.
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError>;
+    /// Verify a raw `signature` over `message` with a raw public key.
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError>;
+    /// Generate a fresh key pair, returning `(private_key, public_key)` as raw bytes.
+    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>);
+}
+
+/// Ed25519 (EdDSA) over 32-byte keys.
+struct Ed25519Scheme;
+
+impl SignatureScheme for Ed25519Scheme {
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
+        let array: [u8; 32] = private_key
+            .try_into()
+            .map_err(|_| VcError::KeyDecode("Ed25519 signing key must be 32 bytes".to_string()))?;
+        Ok(DalekSigningKey::from_bytes(&array)
+            .sign(message)
+            .to_bytes()
+            .to_vec())
+    }
+
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError> {
+        let array: [u8; 32] = public_key.try_into().map_err(|_| {
+            VcError::InvalidPublicKey("Ed25519 public key must be 32 bytes".to_string())
+        })?;
+        let sig = Signature::from_slice(signature)
+            .map_err(|e| VcError::MalformedSignature(e.to_string()))?;
+        DalekVerifyingKey::from_bytes(&array)
+            .map_err(|e| VcError::InvalidPublicKey(e.to_string()))?
+            .verify(message, &sig)
+            .map_err(|_| VcError::SignatureVerificationFailed)
+    }
+
+    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>) {
+        let signing_key = DalekSigningKey::from_bytes(&random_seed());
+        (
+            signing_key.to_bytes().to_vec(),
+            signing_key.verifying_key().to_bytes().to_vec(),
+        )
+    }
+}
+
+/// ML-DSA (FIPS 204) for a given parameter set `P` (`MlDsa44` / `MlDsa65` / `MlDsa87`).
+/// Thin adapter over the `mldsa_*` helpers, which own the hedged-signing and panic-guard
+/// details.
+struct MlDsaScheme<P>(PhantomData<P>);
+
+impl<P: ml_dsa::MlDsaParams> SignatureScheme for MlDsaScheme<P> {
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
+        mldsa_sign::<P>(private_key, message)
+    }
+
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError> {
+        mldsa_verify::<P>(public_key, message, signature)
+    }
+
+    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>) {
+        mldsa_generate::<P>()
+    }
+}
+
+/// Sign `message` with a raw FIPS 204 expanded ML-DSA signing key, returning the raw
+/// signature bytes. Uses the **hedged** (randomized) variant with an empty context, as
+/// recommended by FIPS 204 §3.4 — fresh randomness mitigates fault attacks and bad-RNG
+/// edge cases. Signatures are therefore non-deterministic (still verifiable by anyone).
+///
+/// `from_expanded` does not validate the key and can panic on a malformed (but
+/// correctly-sized) key. The private key is caller-supplied, so the whole sign is run
+/// inside `catch_unwind` and a panic is reported as a [VcError] rather than aborting.
+#[allow(deprecated)] // from_expanded: importing an external expanded key is the intent here
+fn mldsa_sign<P: ml_dsa::MlDsaParams>(sk_bytes: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
+    let encoded = ml_dsa::ExpandedSigningKeyBytes::<P>::try_from(sk_bytes)
+        .map_err(|_| VcError::KeyDecode("ML-DSA signing key has the wrong length".to_string()))?;
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_expanded(&encoded);
+        signing_key.sign_randomized(message, b"", &mut getrandom_v04::SysRng)
+    }))
+    .map_err(|_| VcError::KeyDecode("ML-DSA signing key is malformed".to_string()))?;
+
+    let signature = result.map_err(|_| VcError::KeyDecode("ML-DSA signing failed".to_string()))?;
+    Ok(signature.encode().to_vec())
+}
+
+/// Verify a raw ML-DSA signature over `message` with a raw FIPS 204 public key.
+fn mldsa_verify<P: ml_dsa::MlDsaParams>(
+    pk_bytes: &[u8],
+    message: &[u8],
+    signature: &[u8],
+) -> Result<(), VcError> {
+    let encoded_pk = ml_dsa::EncodedVerifyingKey::<P>::try_from(pk_bytes).map_err(|_| {
+        VcError::InvalidPublicKey("ML-DSA public key has the wrong length".to_string())
+    })?;
+    let verifying_key = ml_dsa::VerifyingKey::<P>::decode(&encoded_pk);
+
+    let encoded_sig = ml_dsa::EncodedSignature::<P>::try_from(signature).map_err(|_| {
+        VcError::MalformedSignature("ML-DSA signature has the wrong length".to_string())
+    })?;
+    let signature = ml_dsa::Signature::<P>::decode(&encoded_sig).ok_or_else(|| {
+        VcError::MalformedSignature("ML-DSA signature failed to decode".to_string())
+    })?;
+
+    if verifying_key.verify_with_context(message, b"", &signature) {
+        Ok(())
+    } else {
+        Err(VcError::SignatureVerificationFailed)
+    }
+}
+
+/// Fill a fresh 32-byte seed from the operating-system CSPRNG, accessed directly through
+/// `getrandom` — the same entropy source `rand::OsRng` wraps. Panics only if the OS RNG is
+/// unavailable, which is unrecoverable and matches the previous `OsRng`-based behavior.
+fn random_seed() -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    getrandom_v04::fill(&mut seed).expect("operating-system RNG is unavailable");
+    seed
+}
+
+/// Generate an ML-DSA key pair from a fresh random seed, returning
+/// `(expanded_signing_key_bytes, verifying_key_bytes)` in their FIPS 204 encodings.
+#[allow(deprecated)] // to_expanded: we intentionally export the expanded key form
+fn mldsa_generate<P: ml_dsa::MlDsaParams>() -> (Vec<u8>, Vec<u8>) {
+    let seed = random_seed();
+    let seed = ml_dsa::B32::try_from(&seed[..]).expect("seed is 32 bytes");
+    let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_seed(&seed);
+    (
+        signing_key.to_expanded().to_vec(),
+        signing_key.verifying_key().encode().to_vec(),
+    )
+}
+
+/// Generate a fresh key pair for `algorithm`, returning `(private_key, public_key)` as raw
+/// bytes suitable for [sign_with_algorithm](crate::UnsignedVerifiableCredential::sign_with_algorithm)
+/// and [verify_with_algorithm](crate::VerifiableCredential::verify_with_algorithm). For
+/// typed keys that carry their algorithm, use [generate_keypair].
+pub fn generate_keypair_bytes(algorithm: Algorithm) -> (Vec<u8>, Vec<u8>) {
+    algorithm.scheme().generate_keypair()
+}
+
+/// Whether a key is a private (signing) or public (verifying) key — selects which length a
+/// key is checked against.
+#[derive(Clone, Copy)]
+enum KeyRole {
+    Signing,
+    Verifying,
+}
+
+/// Validate that `len` matches `algorithm`'s key length for the given `role`.
+fn check_key_length(algorithm: Algorithm, len: usize, role: KeyRole) -> Result<(), VcError> {
+    let (private_len, public_len) = algorithm.key_lengths();
+    let (expected, label) = match role {
+        KeyRole::Signing => (private_len, "signing"),
+        KeyRole::Verifying => (public_len, "verifying"),
+    };
+    if len != expected {
+        return Err(VcError::KeyDecode(format!(
+            "{algorithm:?} {label} key must be {expected} bytes, got {len}"
+        )));
+    }
+    Ok(())
+}
+
+/// A private (signing) key: an [Algorithm] tag plus its raw key bytes.
+///
+/// The algorithm travels with the bytes, so [sign](crate::UnsignedVerifiableCredential::sign)
+/// reads it from the key and a caller never has to pass the algorithm separately. The byte
+/// length is checked against the algorithm at construction. For raw-byte interop (an HSM,
+/// the wasm ABI, a cross-language partner) use
+/// [sign_with_algorithm](crate::UnsignedVerifiableCredential::sign_with_algorithm) with the
+/// raw bytes instead.
+#[derive(Clone)]
+pub struct SigningKey {
+    algorithm: Algorithm,
+    bytes: Vec<u8>,
+}
+
+/// A public (verifying) key: an [Algorithm] tag plus its raw key bytes. See [SigningKey].
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct VerifyingKey {
+    algorithm: Algorithm,
+    bytes: Vec<u8>,
+}
+
+impl SigningKey {
+    /// Wrap raw signing-key bytes for `algorithm`, checking the length matches (Ed25519:
+    /// 32 bytes; ML-DSA: the FIPS 204 expanded signing key). Errors with
+    /// [VcError::KeyDecode] on a length mismatch.
+    pub fn new(algorithm: Algorithm, bytes: &[u8]) -> Result<Self, VcError> {
+        check_key_length(algorithm, bytes.len(), KeyRole::Signing)?;
+        Ok(Self {
+            algorithm,
+            bytes: bytes.to_vec(),
+        })
+    }
+
+    /// The algorithm this key signs with.
+    pub fn algorithm(&self) -> Algorithm {
+        self.algorithm
+    }
+
+    /// The raw key bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl VerifyingKey {
+    /// Wrap raw verifying-key bytes for `algorithm`, checking the length matches (Ed25519:
+    /// 32 bytes; ML-DSA: the FIPS 204 public key). Errors with [VcError::KeyDecode] on a
+    /// length mismatch.
+    pub fn new(algorithm: Algorithm, bytes: &[u8]) -> Result<Self, VcError> {
+        check_key_length(algorithm, bytes.len(), KeyRole::Verifying)?;
+        Ok(Self {
+            algorithm,
+            bytes: bytes.to_vec(),
+        })
+    }
+
+    /// The algorithm this key verifies.
+    pub fn algorithm(&self) -> Algorithm {
+        self.algorithm
+    }
+
+    /// The raw key bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+// Redact the secret in Debug output so it can't leak into logs.
+impl fmt::Debug for SigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SigningKey")
+            .field("algorithm", &self.algorithm)
+            .field("bytes", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// A key pair produced by [generate_keypair].
+#[derive(Clone)]
+pub struct KeyPair {
+    /// The private key used to sign credentials.
+    pub signing_key: SigningKey,
+    /// The public key used to verify credentials.
+    pub verifying_key: VerifyingKey,
+}
+
+/// Generate a fresh typed [KeyPair] for `algorithm`. The algorithm travels with each key,
+/// so the resulting keys can be passed straight to
+/// [sign](crate::UnsignedVerifiableCredential::sign) /
+/// [verify](crate::VerifiableCredential::verify).
+pub fn generate_keypair(algorithm: Algorithm) -> KeyPair {
+    let (signing_key, verifying_key) = generate_keypair_bytes(algorithm);
+    KeyPair {
+        signing_key: SigningKey {
+            algorithm,
+            bytes: signing_key,
+        },
+        verifying_key: VerifyingKey {
+            algorithm,
+            bytes: verifying_key,
+        },
+    }
+}

--- a/src/crypto/ed25519.rs
+++ b/src/crypto/ed25519.rs
@@ -1,0 +1,48 @@
+//! Ed25519 (EdDSA) signature scheme.
+
+use super::SignatureScheme;
+use crate::crypto::random_seed;
+use crate::VcError;
+use ed25519_dalek::{
+    Signature, Signer, SigningKey as DalekSigningKey, Verifier, VerifyingKey as DalekVerifyingKey,
+};
+
+/// Ed25519 (EdDSA) over 32-byte keys.
+struct Ed25519Scheme;
+
+impl SignatureScheme for Ed25519Scheme {
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
+        let array: [u8; 32] = private_key
+            .try_into()
+            .map_err(|_| VcError::KeyDecode("Ed25519 signing key must be 32 bytes".to_string()))?;
+        Ok(DalekSigningKey::from_bytes(&array)
+            .sign(message)
+            .to_bytes()
+            .to_vec())
+    }
+
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError> {
+        let array: [u8; 32] = public_key.try_into().map_err(|_| {
+            VcError::InvalidPublicKey("Ed25519 public key must be 32 bytes".to_string())
+        })?;
+        let sig = Signature::from_slice(signature)
+            .map_err(|e| VcError::MalformedSignature(e.to_string()))?;
+        DalekVerifyingKey::from_bytes(&array)
+            .map_err(|e| VcError::InvalidPublicKey(e.to_string()))?
+            .verify(message, &sig)
+            .map_err(|_| VcError::SignatureVerificationFailed)
+    }
+
+    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>) {
+        let signing_key = DalekSigningKey::from_bytes(&random_seed());
+        (
+            signing_key.to_bytes().to_vec(),
+            signing_key.verifying_key().to_bytes().to_vec(),
+        )
+    }
+}
+
+/// The Ed25519 [SignatureScheme], boxed for runtime dispatch by [Algorithm::scheme](super::Algorithm::scheme).
+pub(super) fn scheme() -> Box<dyn SignatureScheme> {
+    Box::new(Ed25519Scheme)
+}

--- a/src/crypto/mldsa.rs
+++ b/src/crypto/mldsa.rs
@@ -1,0 +1,104 @@
+//! ML-DSA (FIPS 204) signature scheme, for the three parameter sets.
+//!
+//! This is the single file that depends on the `ml-dsa` backend crate. To swap in a
+//! different ML-DSA implementation (e.g. a FIPS-validated module or an HSM over FFI), this
+//! is the only place that changes — the rest of the toolkit talks to [SignatureScheme].
+
+use super::SignatureScheme;
+use crate::crypto::random_seed;
+use crate::VcError;
+use std::marker::PhantomData;
+
+/// ML-DSA (FIPS 204) for a given parameter set `P` (`MlDsa44` / `MlDsa65` / `MlDsa87`).
+/// Thin adapter over the `mldsa_*` helpers, which own the hedged-signing and panic-guard
+/// details.
+struct MlDsaScheme<P>(PhantomData<P>);
+
+impl<P: ml_dsa::MlDsaParams> SignatureScheme for MlDsaScheme<P> {
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
+        mldsa_sign::<P>(private_key, message)
+    }
+
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError> {
+        mldsa_verify::<P>(public_key, message, signature)
+    }
+
+    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>) {
+        mldsa_generate::<P>()
+    }
+}
+
+/// Sign `message` with a raw FIPS 204 expanded ML-DSA signing key, returning the raw
+/// signature bytes. Uses the **hedged** (randomized) variant with an empty context, as
+/// recommended by FIPS 204 §3.4 — fresh randomness mitigates fault attacks and bad-RNG
+/// edge cases. Signatures are therefore non-deterministic (still verifiable by anyone).
+///
+/// `from_expanded` does not validate the key and can panic on a malformed (but
+/// correctly-sized) key. The private key is caller-supplied, so the whole sign is run
+/// inside `catch_unwind` and a panic is reported as a [VcError] rather than aborting.
+#[allow(deprecated)] // from_expanded: importing an external expanded key is the intent here
+fn mldsa_sign<P: ml_dsa::MlDsaParams>(sk_bytes: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
+    let encoded = ml_dsa::ExpandedSigningKeyBytes::<P>::try_from(sk_bytes)
+        .map_err(|_| VcError::KeyDecode("ML-DSA signing key has the wrong length".to_string()))?;
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_expanded(&encoded);
+        signing_key.sign_randomized(message, b"", &mut getrandom_v04::SysRng)
+    }))
+    .map_err(|_| VcError::KeyDecode("ML-DSA signing key is malformed".to_string()))?;
+
+    let signature = result.map_err(|_| VcError::KeyDecode("ML-DSA signing failed".to_string()))?;
+    Ok(signature.encode().to_vec())
+}
+
+/// Verify a raw ML-DSA signature over `message` with a raw FIPS 204 public key.
+fn mldsa_verify<P: ml_dsa::MlDsaParams>(
+    pk_bytes: &[u8],
+    message: &[u8],
+    signature: &[u8],
+) -> Result<(), VcError> {
+    let encoded_pk = ml_dsa::EncodedVerifyingKey::<P>::try_from(pk_bytes).map_err(|_| {
+        VcError::InvalidPublicKey("ML-DSA public key has the wrong length".to_string())
+    })?;
+    let verifying_key = ml_dsa::VerifyingKey::<P>::decode(&encoded_pk);
+
+    let encoded_sig = ml_dsa::EncodedSignature::<P>::try_from(signature).map_err(|_| {
+        VcError::MalformedSignature("ML-DSA signature has the wrong length".to_string())
+    })?;
+    let signature = ml_dsa::Signature::<P>::decode(&encoded_sig).ok_or_else(|| {
+        VcError::MalformedSignature("ML-DSA signature failed to decode".to_string())
+    })?;
+
+    if verifying_key.verify_with_context(message, b"", &signature) {
+        Ok(())
+    } else {
+        Err(VcError::SignatureVerificationFailed)
+    }
+}
+
+/// Generate an ML-DSA key pair from a fresh random seed, returning
+/// `(expanded_signing_key_bytes, verifying_key_bytes)` in their FIPS 204 encodings.
+#[allow(deprecated)] // to_expanded: we intentionally export the expanded key form
+fn mldsa_generate<P: ml_dsa::MlDsaParams>() -> (Vec<u8>, Vec<u8>) {
+    let seed = random_seed();
+    let seed = ml_dsa::B32::try_from(&seed[..]).expect("seed is 32 bytes");
+    let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_seed(&seed);
+    (
+        signing_key.to_expanded().to_vec(),
+        signing_key.verifying_key().encode().to_vec(),
+    )
+}
+
+/// The ML-DSA [SignatureScheme] for each parameter set, boxed for runtime dispatch by
+/// [Algorithm::scheme](super::Algorithm::scheme).
+pub(super) fn scheme_44() -> Box<dyn SignatureScheme> {
+    Box::new(MlDsaScheme::<ml_dsa::MlDsa44>(PhantomData))
+}
+
+pub(super) fn scheme_65() -> Box<dyn SignatureScheme> {
+    Box::new(MlDsaScheme::<ml_dsa::MlDsa65>(PhantomData))
+}
+
+pub(super) fn scheme_87() -> Box<dyn SignatureScheme> {
+    Box::new(MlDsaScheme::<ml_dsa::MlDsa87>(PhantomData))
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -6,16 +6,17 @@
 //! special-cased, it is just another [Algorithm]. The credential `sign` / `verify`
 //! methods read the algorithm from the key, so the same call works for any algorithm.
 //!
-//! Internally each algorithm is a [SignatureScheme] implementation selected by
-//! [Algorithm::scheme]; that trait is the seam where a FIPS-validated / HSM backend can be
-//! dropped in as one more implementation without touching the public API.
+//! Each algorithm is a [SignatureScheme] implementation living in its own submodule
+//! ([ed25519], [mldsa]), selected at runtime by [Algorithm::scheme]. That trait is the seam
+//! where a FIPS-validated / HSM backend can be dropped in as one more implementation
+//! without touching the public API — and the per-algorithm split keeps each backend's
+//! dependencies and details confined to one file.
+
+mod ed25519;
+mod mldsa;
 
 use crate::VcError;
-use ed25519_dalek::{
-    Signature, Signer, SigningKey as DalekSigningKey, Verifier, VerifyingKey as DalekVerifyingKey,
-};
 use std::fmt;
-use std::marker::PhantomData;
 
 /// A signature algorithm the toolkit can sign and verify with.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -73,16 +74,16 @@ impl Algorithm {
         }
     }
 
-    /// The single dispatch point from the runtime [Algorithm] tag to the compile-time
-    /// [SignatureScheme] that implements it. Every sign / verify / keygen call routes
-    /// through here, so this is the only place that enumerates the variants — adding an
-    /// algorithm means adding one arm here plus one trait impl.
+    /// The single dispatch point from the runtime [Algorithm] tag to the [SignatureScheme]
+    /// that implements it. Every sign / verify / keygen call routes through here, so this
+    /// is the only place that enumerates the variants — adding an algorithm means adding one
+    /// arm here plus one submodule.
     fn scheme(self) -> Box<dyn SignatureScheme> {
         match self {
-            Algorithm::Ed25519 => Box::new(Ed25519Scheme),
-            Algorithm::MlDsa44 => Box::new(MlDsaScheme::<ml_dsa::MlDsa44>(PhantomData)),
-            Algorithm::MlDsa65 => Box::new(MlDsaScheme::<ml_dsa::MlDsa65>(PhantomData)),
-            Algorithm::MlDsa87 => Box::new(MlDsaScheme::<ml_dsa::MlDsa87>(PhantomData)),
+            Algorithm::Ed25519 => ed25519::scheme(),
+            Algorithm::MlDsa44 => mldsa::scheme_44(),
+            Algorithm::MlDsa65 => mldsa::scheme_65(),
+            Algorithm::MlDsa87 => mldsa::scheme_87(),
         }
     }
 }
@@ -108,12 +109,11 @@ pub(crate) fn verify_bytes(
     algorithm.scheme().verify(public_key, message, signature)
 }
 
-/// The per-algorithm signing operations, behind one interface. Implemented by a
-/// zero-sized marker per scheme ([Ed25519Scheme], [MlDsaScheme]) and selected at runtime
-/// by [Algorithm::scheme]. Keeping this private means the public API stays the [Algorithm]
-/// enum and the key types; this trait only removes the duplicated `match` arms and
-/// provides the seam where a FIPS-validated / HSM backend can be dropped in as one extra
-/// impl.
+/// The per-algorithm signing operations, behind one interface. Implemented once per
+/// algorithm in the [ed25519] / [mldsa] submodules and selected at runtime by
+/// [Algorithm::scheme]. Keeping this private means the public API stays the [Algorithm]
+/// enum and the key types; this trait only removes the duplicated `match` arms and provides
+/// the seam where a FIPS-validated / HSM backend can be dropped in as one extra impl.
 trait SignatureScheme {
     /// Sign `message` with a raw private key of this scheme's expected length.
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError>;
@@ -123,128 +123,13 @@ trait SignatureScheme {
     fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>);
 }
 
-/// Ed25519 (EdDSA) over 32-byte keys.
-struct Ed25519Scheme;
-
-impl SignatureScheme for Ed25519Scheme {
-    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
-        let array: [u8; 32] = private_key
-            .try_into()
-            .map_err(|_| VcError::KeyDecode("Ed25519 signing key must be 32 bytes".to_string()))?;
-        Ok(DalekSigningKey::from_bytes(&array)
-            .sign(message)
-            .to_bytes()
-            .to_vec())
-    }
-
-    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError> {
-        let array: [u8; 32] = public_key.try_into().map_err(|_| {
-            VcError::InvalidPublicKey("Ed25519 public key must be 32 bytes".to_string())
-        })?;
-        let sig = Signature::from_slice(signature)
-            .map_err(|e| VcError::MalformedSignature(e.to_string()))?;
-        DalekVerifyingKey::from_bytes(&array)
-            .map_err(|e| VcError::InvalidPublicKey(e.to_string()))?
-            .verify(message, &sig)
-            .map_err(|_| VcError::SignatureVerificationFailed)
-    }
-
-    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>) {
-        let signing_key = DalekSigningKey::from_bytes(&random_seed());
-        (
-            signing_key.to_bytes().to_vec(),
-            signing_key.verifying_key().to_bytes().to_vec(),
-        )
-    }
-}
-
-/// ML-DSA (FIPS 204) for a given parameter set `P` (`MlDsa44` / `MlDsa65` / `MlDsa87`).
-/// Thin adapter over the `mldsa_*` helpers, which own the hedged-signing and panic-guard
-/// details.
-struct MlDsaScheme<P>(PhantomData<P>);
-
-impl<P: ml_dsa::MlDsaParams> SignatureScheme for MlDsaScheme<P> {
-    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
-        mldsa_sign::<P>(private_key, message)
-    }
-
-    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError> {
-        mldsa_verify::<P>(public_key, message, signature)
-    }
-
-    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>) {
-        mldsa_generate::<P>()
-    }
-}
-
-/// Sign `message` with a raw FIPS 204 expanded ML-DSA signing key, returning the raw
-/// signature bytes. Uses the **hedged** (randomized) variant with an empty context, as
-/// recommended by FIPS 204 §3.4 — fresh randomness mitigates fault attacks and bad-RNG
-/// edge cases. Signatures are therefore non-deterministic (still verifiable by anyone).
-///
-/// `from_expanded` does not validate the key and can panic on a malformed (but
-/// correctly-sized) key. The private key is caller-supplied, so the whole sign is run
-/// inside `catch_unwind` and a panic is reported as a [VcError] rather than aborting.
-#[allow(deprecated)] // from_expanded: importing an external expanded key is the intent here
-fn mldsa_sign<P: ml_dsa::MlDsaParams>(sk_bytes: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
-    let encoded = ml_dsa::ExpandedSigningKeyBytes::<P>::try_from(sk_bytes)
-        .map_err(|_| VcError::KeyDecode("ML-DSA signing key has the wrong length".to_string()))?;
-
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_expanded(&encoded);
-        signing_key.sign_randomized(message, b"", &mut getrandom_v04::SysRng)
-    }))
-    .map_err(|_| VcError::KeyDecode("ML-DSA signing key is malformed".to_string()))?;
-
-    let signature = result.map_err(|_| VcError::KeyDecode("ML-DSA signing failed".to_string()))?;
-    Ok(signature.encode().to_vec())
-}
-
-/// Verify a raw ML-DSA signature over `message` with a raw FIPS 204 public key.
-fn mldsa_verify<P: ml_dsa::MlDsaParams>(
-    pk_bytes: &[u8],
-    message: &[u8],
-    signature: &[u8],
-) -> Result<(), VcError> {
-    let encoded_pk = ml_dsa::EncodedVerifyingKey::<P>::try_from(pk_bytes).map_err(|_| {
-        VcError::InvalidPublicKey("ML-DSA public key has the wrong length".to_string())
-    })?;
-    let verifying_key = ml_dsa::VerifyingKey::<P>::decode(&encoded_pk);
-
-    let encoded_sig = ml_dsa::EncodedSignature::<P>::try_from(signature).map_err(|_| {
-        VcError::MalformedSignature("ML-DSA signature has the wrong length".to_string())
-    })?;
-    let signature = ml_dsa::Signature::<P>::decode(&encoded_sig).ok_or_else(|| {
-        VcError::MalformedSignature("ML-DSA signature failed to decode".to_string())
-    })?;
-
-    if verifying_key.verify_with_context(message, b"", &signature) {
-        Ok(())
-    } else {
-        Err(VcError::SignatureVerificationFailed)
-    }
-}
-
 /// Fill a fresh 32-byte seed from the operating-system CSPRNG, accessed directly through
-/// `getrandom` — the same entropy source `rand::OsRng` wraps. Panics only if the OS RNG is
-/// unavailable, which is unrecoverable and matches the previous `OsRng`-based behavior.
+/// `getrandom`. Shared by the per-algorithm key generators. Panics only if the OS RNG is
+/// unavailable, which is unrecoverable.
 fn random_seed() -> [u8; 32] {
     let mut seed = [0u8; 32];
     getrandom_v04::fill(&mut seed).expect("operating-system RNG is unavailable");
     seed
-}
-
-/// Generate an ML-DSA key pair from a fresh random seed, returning
-/// `(expanded_signing_key_bytes, verifying_key_bytes)` in their FIPS 204 encodings.
-#[allow(deprecated)] // to_expanded: we intentionally export the expanded key form
-fn mldsa_generate<P: ml_dsa::MlDsaParams>() -> (Vec<u8>, Vec<u8>) {
-    let seed = random_seed();
-    let seed = ml_dsa::B32::try_from(&seed[..]).expect("seed is 32 bytes");
-    let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_seed(&seed);
-    (
-        signing_key.to_expanded().to_vec(),
-        signing_key.verifying_key().encode().to_vec(),
-    )
 }
 
 /// Generate a fresh key pair for `algorithm`, returning `(private_key, public_key)` as raw

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,9 +40,9 @@ pub enum VcError {
     #[error("the credential has expired (validUntil check failed)")]
     Expired,
 
-    /// The `proofValue` was not valid base64.
-    #[error("failed to decode proofValue from base64: {0}")]
-    ProofDecode(#[from] base64::DecodeError),
+    /// The `proofValue` could not be decoded from its multibase representation.
+    #[error("failed to decode proofValue: {0}")]
+    ProofDecode(String),
 
     /// The decoded `proofValue` was not a well-formed signature for the proof's algorithm
     /// (e.g. wrong length).

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,17 +44,27 @@ pub enum VcError {
     #[error("failed to decode proofValue from base64: {0}")]
     ProofDecode(#[from] base64::DecodeError),
 
-    /// The decoded `proofValue` was not a well-formed Ed25519 signature.
-    #[error("malformed signature in proof")]
-    MalformedSignature(#[source] ed25519_dalek::SignatureError),
+    /// The decoded `proofValue` was not a well-formed signature for the proof's algorithm
+    /// (e.g. wrong length).
+    #[error("malformed signature in proof: {0}")]
+    MalformedSignature(String),
 
-    /// The supplied public key bytes were not a valid Ed25519 verifying key.
-    #[error("invalid public key")]
-    InvalidPublicKey(#[source] ed25519_dalek::SignatureError),
+    /// The supplied public key bytes were not a valid key for the expected algorithm.
+    #[error("invalid public key: {0}")]
+    InvalidPublicKey(String),
+
+    /// A key could not be decoded, or its length did not match the algorithm.
+    #[error("failed to decode key: {0}")]
+    KeyDecode(String),
+
+    /// The proof's `cryptosuite` (or the requested algorithm) is not one this library
+    /// can sign or verify.
+    #[error("unsupported cryptosuite: {0}")]
+    UnsupportedCryptosuite(String),
 
     /// The signature did not verify against the credential and public key.
     #[error("signature verification failed")]
-    SignatureVerificationFailed(#[source] ed25519_dalek::SignatureError),
+    SignatureVerificationFailed,
 
     /// A serialization-format codec (e.g. CBOR or Protobuf) failed to decode or
     /// encode a credential. Carries the underlying format-specific error.

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,12 @@ pub enum VcError {
     #[error("unsupported cryptosuite: {0}")]
     UnsupportedCryptosuite(String),
 
+    /// The proof carries no `cryptosuite`, so the verification algorithm cannot be
+    /// determined. `DataIntegrityProof` requires one; a proof without it is rejected
+    /// rather than being assumed to be Ed25519.
+    #[error("proof is missing a cryptosuite")]
+    MissingCryptosuite,
+
     /// The signature did not verify against the credential and public key.
     #[error("signature verification failed")]
     SignatureVerificationFailed,

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,14 +9,6 @@ use thiserror::Error;
 /// Errors that can occur while validating, signing, or verifying a credential.
 #[derive(Debug, Error)]
 pub enum VcError {
-    /// The supplied private key was not 32 bytes.
-    #[error("invalid private key length: expected 32 bytes")]
-    InvalidPrivateKeyLength,
-
-    /// The supplied public key was not 32 bytes.
-    #[error("invalid public key length: expected 32 bytes")]
-    InvalidPublicKeyLength,
-
     /// The `credentialSubject` did not satisfy the supplied JSON Schema.
     #[error("credential subject does not match schema")]
     SchemaMismatch,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,7 @@ pub struct Proof {
 
 impl Proof {
     /// Construct a `DataIntegrityProof` for the given `cryptosuite`, carrying the
-    /// base64-encoded `proof_value`. This is the entry point for wrapping an
+    /// multibase-encoded `proof_value`. This is the entry point for wrapping an
     /// externally-computed signature (e.g. an ML-DSA signature produced out of process):
     /// build the proof, attach it with [VerifiableCredential::from_parts], and the
     /// credential serializes like any other.
@@ -293,7 +293,7 @@ impl Proof {
         }
     }
 
-    /// The base64-encoded `proofValue` (the raw signature bytes, base64-encoded).
+    /// The `proofValue` string (the raw signature bytes, multibase base58btc-encoded).
     pub fn proof_value(&self) -> &str {
         &self.proof_value
     }
@@ -364,7 +364,7 @@ impl Proof {
         self
     }
 
-    /// Set the base64-encoded `proofValue`. Use this to inject an externally-computed
+    /// Set the multibase-encoded `proofValue`. Use this to inject an externally-computed
     /// signature (e.g. ML-DSA signed out of process) into a proof.
     pub fn set_proof_value(mut self, proof_value: String) -> Self {
         self.proof_value = proof_value;
@@ -478,10 +478,11 @@ impl UnsignedVerifiableCredential {
     /// Sign with the given [Algorithm] and a raw private key of the matching length
     /// (Ed25519: 32-byte seed; ML-DSA: the FIPS 204 expanded signing key — 2560 / 4032 /
     /// 4896 bytes for ML-DSA-44 / 65 / 87). The signature is taken over the JCS-canonical
-    /// credential and stored base64-encoded in a `DataIntegrityProof` whose `cryptosuite`
-    /// is [Algorithm::cryptosuite].
+    /// credential and stored multibase base58btc-encoded in a `DataIntegrityProof` whose
+    /// `cryptosuite` is [Algorithm::cryptosuite].
     ///
-    /// ML-DSA signing is deterministic (FIPS 204 optional variant) with an empty context.
+    /// ML-DSA signing is hedged (FIPS 204 randomized variant) with an empty context, so
+    /// signatures are non-deterministic but remain verifiable by anyone.
     pub fn sign_with_algorithm(
         self,
         algorithm: Algorithm,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,13 @@ use ed25519_dalek::{
     Signature, Signer, SigningKey as DalekSigningKey, Verifier, VerifyingKey as DalekVerifyingKey,
 };
 use multibase::Base;
-use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::formats::PreferOne;
 use serde_with::{serde_as, OneOrMany};
 use std::collections::HashMap;
 use std::fmt;
+use std::marker::PhantomData;
 use url::Url;
 
 pub mod bindings;
@@ -489,20 +489,7 @@ impl UnsignedVerifiableCredential {
         private_key: &[u8],
     ) -> Result<VerifiableCredential, VcError> {
         let message = self.signing_payload()?;
-        let signature = match algorithm {
-            Algorithm::Ed25519 => {
-                let array: [u8; 32] = private_key
-                    .try_into()
-                    .map_err(|_| VcError::InvalidPrivateKeyLength)?;
-                DalekSigningKey::from_bytes(&array)
-                    .sign(&message)
-                    .to_bytes()
-                    .to_vec()
-            }
-            Algorithm::MlDsa44 => mldsa_sign::<ml_dsa::MlDsa44>(private_key, &message)?,
-            Algorithm::MlDsa65 => mldsa_sign::<ml_dsa::MlDsa65>(private_key, &message)?,
-            Algorithm::MlDsa87 => mldsa_sign::<ml_dsa::MlDsa87>(private_key, &message)?,
-        };
+        let signature = algorithm.scheme().sign(private_key, &message)?;
         let proof = Proof::new_data_integrity(
             algorithm.cryptosuite(),
             multibase::encode(Base::Base58Btc, signature),
@@ -580,22 +567,7 @@ impl VerifiableCredential {
         let (_, signature) = multibase::decode(&self.proof.proof_value)
             .map_err(|e| VcError::ProofDecode(e.to_string()))?;
 
-        match algorithm {
-            Algorithm::Ed25519 => {
-                let array: [u8; 32] = public_key.try_into().map_err(|_| {
-                    VcError::InvalidPublicKey("Ed25519 public key must be 32 bytes".to_string())
-                })?;
-                let sig = Signature::from_slice(&signature)
-                    .map_err(|e| VcError::MalformedSignature(e.to_string()))?;
-                DalekVerifyingKey::from_bytes(&array)
-                    .map_err(|e| VcError::InvalidPublicKey(e.to_string()))?
-                    .verify(&message, &sig)
-                    .map_err(|_| VcError::SignatureVerificationFailed)
-            }
-            Algorithm::MlDsa44 => mldsa_verify::<ml_dsa::MlDsa44>(public_key, &message, &signature),
-            Algorithm::MlDsa65 => mldsa_verify::<ml_dsa::MlDsa65>(public_key, &message, &signature),
-            Algorithm::MlDsa87 => mldsa_verify::<ml_dsa::MlDsa87>(public_key, &message, &signature),
-        }
+        algorithm.scheme().verify(public_key, &message, &signature)
     }
 
     /// Verify by reading the algorithm from the proof's `cryptosuite` and dispatching to
@@ -651,6 +623,88 @@ impl Algorithm {
             _ => None,
         }
     }
+
+    /// The single dispatch point from the runtime [Algorithm] tag to the compile-time
+    /// [SignatureScheme] that implements it. Every sign / verify / keygen call routes
+    /// through here, so this is the only place that enumerates the variants — adding an
+    /// algorithm means adding one arm here plus one trait impl.
+    fn scheme(self) -> Box<dyn SignatureScheme> {
+        match self {
+            Algorithm::Ed25519 => Box::new(Ed25519Scheme),
+            Algorithm::MlDsa44 => Box::new(MlDsaScheme::<ml_dsa::MlDsa44>(PhantomData)),
+            Algorithm::MlDsa65 => Box::new(MlDsaScheme::<ml_dsa::MlDsa65>(PhantomData)),
+            Algorithm::MlDsa87 => Box::new(MlDsaScheme::<ml_dsa::MlDsa87>(PhantomData)),
+        }
+    }
+}
+
+/// The per-algorithm signing operations, behind one interface. Implemented by a
+/// zero-sized marker per scheme ([Ed25519Scheme], [MlDsaScheme]) and selected at runtime
+/// by [Algorithm::scheme]. Keeping this internal means the public API stays the
+/// [Algorithm] enum and the methods on the credential; this trait only removes the
+/// duplicated `match` arms and provides the seam where a FIPS-validated / HSM backend can
+/// be dropped in as one extra impl.
+trait SignatureScheme {
+    /// Sign `message` with a raw private key of this scheme's expected length.
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError>;
+    /// Verify a raw `signature` over `message` with a raw public key.
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError>;
+    /// Generate a fresh key pair, returning `(private_key, public_key)` as raw bytes.
+    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>);
+}
+
+/// Ed25519 (EdDSA) over 32-byte keys.
+struct Ed25519Scheme;
+
+impl SignatureScheme for Ed25519Scheme {
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
+        let array: [u8; 32] = private_key
+            .try_into()
+            .map_err(|_| VcError::InvalidPrivateKeyLength)?;
+        Ok(DalekSigningKey::from_bytes(&array)
+            .sign(message)
+            .to_bytes()
+            .to_vec())
+    }
+
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError> {
+        let array: [u8; 32] = public_key.try_into().map_err(|_| {
+            VcError::InvalidPublicKey("Ed25519 public key must be 32 bytes".to_string())
+        })?;
+        let sig = Signature::from_slice(signature)
+            .map_err(|e| VcError::MalformedSignature(e.to_string()))?;
+        DalekVerifyingKey::from_bytes(&array)
+            .map_err(|e| VcError::InvalidPublicKey(e.to_string()))?
+            .verify(message, &sig)
+            .map_err(|_| VcError::SignatureVerificationFailed)
+    }
+
+    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>) {
+        let signing_key = DalekSigningKey::from_bytes(&random_seed());
+        (
+            signing_key.to_bytes().to_vec(),
+            signing_key.verifying_key().to_bytes().to_vec(),
+        )
+    }
+}
+
+/// ML-DSA (FIPS 204) for a given parameter set `P` (`MlDsa44` / `MlDsa65` / `MlDsa87`).
+/// Thin adapter over the `mldsa_*` helpers, which own the hedged-signing and
+/// panic-guard details.
+struct MlDsaScheme<P>(PhantomData<P>);
+
+impl<P: ml_dsa::MlDsaParams> SignatureScheme for MlDsaScheme<P> {
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
+        mldsa_sign::<P>(private_key, message)
+    }
+
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError> {
+        mldsa_verify::<P>(public_key, message, signature)
+    }
+
+    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>) {
+        mldsa_generate::<P>()
+    }
 }
 
 /// Sign `message` with a raw FIPS 204 expanded ML-DSA signing key, returning the raw
@@ -701,13 +755,20 @@ fn mldsa_verify<P: ml_dsa::MlDsaParams>(
     }
 }
 
+/// Fill a fresh 32-byte seed from the operating-system CSPRNG, accessed directly through
+/// `getrandom` — the same entropy source `rand::OsRng` wraps. Panics only if the OS RNG is
+/// unavailable, which is unrecoverable and matches the previous `OsRng`-based behavior.
+fn random_seed() -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    getrandom_v04::fill(&mut seed).expect("operating-system RNG is unavailable");
+    seed
+}
+
 /// Generate an ML-DSA key pair from a fresh random seed, returning
 /// `(expanded_signing_key_bytes, verifying_key_bytes)` in their FIPS 204 encodings.
 #[allow(deprecated)] // to_expanded: we intentionally export the expanded key form
 fn mldsa_generate<P: ml_dsa::MlDsaParams>() -> (Vec<u8>, Vec<u8>) {
-    use rand::RngCore;
-    let mut seed = [0u8; 32];
-    OsRng.fill_bytes(&mut seed);
+    let seed = random_seed();
     let seed = ml_dsa::B32::try_from(&seed[..]).expect("seed is 32 bytes");
     let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_seed(&seed);
     (
@@ -720,18 +781,7 @@ fn mldsa_generate<P: ml_dsa::MlDsaParams>() -> (Vec<u8>, Vec<u8>) {
 /// raw bytes suitable for [UnsignedVerifiableCredential::sign_with_algorithm] and
 /// [VerifiableCredential::verify_with_algorithm].
 pub fn generate_keypair_bytes(algorithm: Algorithm) -> (Vec<u8>, Vec<u8>) {
-    match algorithm {
-        Algorithm::Ed25519 => {
-            let signing_key = DalekSigningKey::generate(&mut OsRng);
-            (
-                signing_key.to_bytes().to_vec(),
-                signing_key.verifying_key().to_bytes().to_vec(),
-            )
-        }
-        Algorithm::MlDsa44 => mldsa_generate::<ml_dsa::MlDsa44>(),
-        Algorithm::MlDsa65 => mldsa_generate::<ml_dsa::MlDsa65>(),
-        Algorithm::MlDsa87 => mldsa_generate::<ml_dsa::MlDsa87>(),
-    }
+    algorithm.scheme().generate_keypair()
 }
 
 /// A 32-byte Ed25519 private key, used to [sign](UnsignedVerifiableCredential::sign)
@@ -822,8 +872,7 @@ pub struct KeyPair {
 
 /// Generate a new Ed25519 [KeyPair].
 pub fn generate_keypair() -> KeyPair {
-    let mut csprng = OsRng;
-    let signing_key = DalekSigningKey::generate(&mut csprng);
+    let signing_key = DalekSigningKey::from_bytes(&random_seed());
     let verifying_key = signing_key.verifying_key();
 
     KeyPair {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
-use base64::{prelude::BASE64_STANDARD, Engine};
 use chrono::{DateTime, Utc};
 use ed25519_dalek::{
     Signature, Signer, SigningKey as DalekSigningKey, Verifier, VerifyingKey as DalekVerifyingKey,
 };
+use multibase::Base;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -502,8 +502,10 @@ impl UnsignedVerifiableCredential {
             Algorithm::MlDsa65 => mldsa_sign::<ml_dsa::MlDsa65>(private_key, &message)?,
             Algorithm::MlDsa87 => mldsa_sign::<ml_dsa::MlDsa87>(private_key, &message)?,
         };
-        let proof =
-            Proof::new_data_integrity(algorithm.cryptosuite(), BASE64_STANDARD.encode(signature));
+        let proof = Proof::new_data_integrity(
+            algorithm.cryptosuite(),
+            multibase::encode(Base::Base58Btc, signature),
+        );
 
         Ok(VerifiableCredential {
             unsigned: self,
@@ -574,7 +576,8 @@ impl VerifiableCredential {
         self.check_validity_period()?;
 
         let message = self.unsigned.signing_payload()?;
-        let signature = BASE64_STANDARD.decode(&self.proof.proof_value)?;
+        let (_, signature) = multibase::decode(&self.proof.proof_value)
+            .map_err(|e| VcError::ProofDecode(e.to_string()))?;
 
         match algorithm {
             Algorithm::Ed25519 => {
@@ -650,15 +653,25 @@ impl Algorithm {
 }
 
 /// Sign `message` with a raw FIPS 204 expanded ML-DSA signing key, returning the raw
-/// signature bytes. Deterministic variant, empty context.
+/// signature bytes. Uses the **hedged** (randomized) variant with an empty context, as
+/// recommended by FIPS 204 §3.4 — fresh randomness mitigates fault attacks and bad-RNG
+/// edge cases. Signatures are therefore non-deterministic (still verifiable by anyone).
+///
+/// `from_expanded` does not validate the key and can panic on a malformed (but
+/// correctly-sized) key. The private key is caller-supplied, so the whole sign is run
+/// inside `catch_unwind` and a panic is reported as a [VcError] rather than aborting.
 #[allow(deprecated)] // from_expanded: importing an external expanded key is the intent here
 fn mldsa_sign<P: ml_dsa::MlDsaParams>(sk_bytes: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
     let encoded = ml_dsa::ExpandedSigningKeyBytes::<P>::try_from(sk_bytes)
         .map_err(|_| VcError::KeyDecode("ML-DSA signing key has the wrong length".to_string()))?;
-    let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_expanded(&encoded);
-    let signature = signing_key
-        .sign_deterministic(message, b"")
-        .map_err(|_| VcError::KeyDecode("ML-DSA signing failed".to_string()))?;
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_expanded(&encoded);
+        signing_key.sign_randomized(message, b"", &mut getrandom_v04::SysRng)
+    }))
+    .map_err(|_| VcError::KeyDecode("ML-DSA signing key is malformed".to_string()))?;
+
+    let signature = result.map_err(|_| VcError::KeyDecode("ML-DSA signing failed".to_string()))?;
     Ok(signature.encode().to_vec())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,6 +475,17 @@ impl UnsignedVerifiableCredential {
         self.sign_with_algorithm(Algorithm::Ed25519, &signing_key.0)
     }
 
+    /// Sign with a typed [MlDsaSigningKey]. The parameter set is taken from the key, so
+    /// (unlike [sign_with_algorithm](UnsignedVerifiableCredential::sign_with_algorithm)) the
+    /// algorithm and key can't disagree. The ML-DSA counterpart of
+    /// [sign](UnsignedVerifiableCredential::sign).
+    pub fn sign_ml_dsa(
+        self,
+        signing_key: &MlDsaSigningKey,
+    ) -> Result<VerifiableCredential, VcError> {
+        self.sign_with_algorithm(signing_key.algorithm, &signing_key.bytes)
+    }
+
     /// Sign with the given [Algorithm] and a raw private key of the matching length
     /// (Ed25519: 32-byte seed; ML-DSA: the FIPS 204 expanded signing key — 2560 / 4032 /
     /// 4896 bytes for ML-DSA-44 / 65 / 87). The signature is taken over the JCS-canonical
@@ -540,14 +551,16 @@ impl VerifiableCredential {
     }
 
     /// Verify an **Ed25519** credential against a typed [VerifyingKey]. Checks the validity
-    /// period, that the proof's `cryptosuite` is `eddsa-jcs-2022`, and the signature. For
-    /// other algorithms use [verify_with_algorithm](VerifiableCredential::verify_with_algorithm)
-    /// or [verify_auto](VerifiableCredential::verify_auto).
+    /// period, that the proof's `cryptosuite` is `eddsa-jcs-2022`, and the signature. A proof
+    /// that carries no `cryptosuite` is rejected ([VcError::MissingCryptosuite]) rather than
+    /// assumed to be Ed25519. For other algorithms use
+    /// [verify_with_algorithm](VerifiableCredential::verify_with_algorithm) or
+    /// [verify_auto](VerifiableCredential::verify_auto).
     pub fn verify(&self, verifying_key: &VerifyingKey) -> Result<(), VcError> {
-        if let Some(suite) = self.proof.cryptosuite.as_deref() {
-            if Algorithm::from_cryptosuite(suite) != Some(Algorithm::Ed25519) {
-                return Err(VcError::UnsupportedCryptosuite(suite.to_string()));
-            }
+        match self.proof.cryptosuite.as_deref() {
+            Some(suite) if Algorithm::from_cryptosuite(suite) == Some(Algorithm::Ed25519) => {}
+            Some(suite) => return Err(VcError::UnsupportedCryptosuite(suite.to_string())),
+            None => return Err(VcError::MissingCryptosuite),
         }
         self.verify_with_algorithm(Algorithm::Ed25519, &verifying_key.0)
     }
@@ -575,10 +588,28 @@ impl VerifiableCredential {
     /// [VcError::UnsupportedCryptosuite] if the proof names a suite this library can't
     /// verify.
     pub fn verify_auto(&self, public_key: &[u8]) -> Result<(), VcError> {
-        let suite = self.proof.cryptosuite.as_deref().unwrap_or("");
+        let suite = self
+            .proof
+            .cryptosuite
+            .as_deref()
+            .ok_or(VcError::MissingCryptosuite)?;
         let algorithm = Algorithm::from_cryptosuite(suite)
             .ok_or_else(|| VcError::UnsupportedCryptosuite(suite.to_string()))?;
         self.verify_with_algorithm(algorithm, public_key)
+    }
+
+    /// Verify against a typed [MlDsaVerifyingKey]. Checks the validity period, that the
+    /// proof's `cryptosuite` matches the key's parameter set (rejecting, e.g., an ML-DSA-87
+    /// proof under an ML-DSA-44 key), and the signature. The ML-DSA counterpart of
+    /// [verify](VerifiableCredential::verify); a proof without a `cryptosuite` is rejected
+    /// with [VcError::MissingCryptosuite].
+    pub fn verify_ml_dsa(&self, verifying_key: &MlDsaVerifyingKey) -> Result<(), VcError> {
+        match self.proof.cryptosuite.as_deref() {
+            Some(suite) if Algorithm::from_cryptosuite(suite) == Some(verifying_key.algorithm) => {}
+            Some(suite) => return Err(VcError::UnsupportedCryptosuite(suite.to_string())),
+            None => return Err(VcError::MissingCryptosuite),
+        }
+        self.verify_with_algorithm(verifying_key.algorithm, &verifying_key.bytes)
     }
 }
 
@@ -621,6 +652,19 @@ impl Algorithm {
             "mldsa65-jcs-2025" => Some(Algorithm::MlDsa65),
             "mldsa87-jcs-2025" => Some(Algorithm::MlDsa87),
             _ => None,
+        }
+    }
+
+    /// The FIPS 204 raw key lengths `(private, public)` in bytes for this ML-DSA parameter
+    /// set, or `None` for non-ML-DSA algorithms. Used to length-check [MlDsaSigningKey] /
+    /// [MlDsaVerifyingKey] at construction. These sizes are fixed by FIPS 204 and pinned by
+    /// the `keypair_byte_lengths_match_wire_contract` test.
+    fn ml_dsa_key_lengths(self) -> Option<(usize, usize)> {
+        match self {
+            Algorithm::Ed25519 => None,
+            Algorithm::MlDsa44 => Some((2560, 1312)),
+            Algorithm::MlDsa65 => Some((4032, 1952)),
+            Algorithm::MlDsa87 => Some((4896, 2592)),
         }
     }
 
@@ -879,4 +923,130 @@ pub fn generate_keypair() -> KeyPair {
         signing_key: SigningKey(signing_key.to_bytes()),
         verifying_key: VerifyingKey(verifying_key.to_bytes()),
     }
+}
+
+/// An ML-DSA private (signing) key bundled with the parameter set it belongs to.
+///
+/// The ML-DSA analogue of [SigningKey]: the parameter set travels with the bytes, the
+/// length is checked against it at construction, and [sign_ml_dsa](UnsignedVerifiableCredential::sign_ml_dsa)
+/// reads the algorithm from the key — so a caller can't pass an ML-DSA-44 key to an
+/// ML-DSA-87 operation, or an ML-DSA key where a verify expects a different parameter set.
+/// For raw-byte interop (an HSM, the wasm ABI, a cross-language partner) use
+/// [sign_with_algorithm](UnsignedVerifiableCredential::sign_with_algorithm) with the raw
+/// key instead.
+#[derive(Clone)]
+pub struct MlDsaSigningKey {
+    algorithm: Algorithm,
+    bytes: Vec<u8>,
+}
+
+/// An ML-DSA public (verifying) key bundled with its parameter set. See [MlDsaSigningKey].
+#[derive(Clone, PartialEq, Eq)]
+pub struct MlDsaVerifyingKey {
+    algorithm: Algorithm,
+    bytes: Vec<u8>,
+}
+
+/// Validate that `algorithm` is an ML-DSA variant and that `len` matches its FIPS 204 key
+/// length (`private` selects which of the pair to check).
+fn check_ml_dsa_key(algorithm: Algorithm, len: usize, private: bool) -> Result<(), VcError> {
+    let (private_len, public_len) = algorithm
+        .ml_dsa_key_lengths()
+        .ok_or_else(|| VcError::KeyDecode(format!("{algorithm:?} is not an ML-DSA algorithm")))?;
+    let expected = if private { private_len } else { public_len };
+    if len != expected {
+        return Err(VcError::KeyDecode(format!(
+            "{algorithm:?} {} key must be {expected} bytes, got {len}",
+            if private { "signing" } else { "verifying" }
+        )));
+    }
+    Ok(())
+}
+
+impl MlDsaSigningKey {
+    /// Wrap raw ML-DSA signing-key bytes for `algorithm`, checking the length matches the
+    /// parameter set. Errors with [VcError::KeyDecode] if `algorithm` is not ML-DSA or the
+    /// length is wrong.
+    pub fn new(algorithm: Algorithm, bytes: &[u8]) -> Result<Self, VcError> {
+        check_ml_dsa_key(algorithm, bytes.len(), true)?;
+        Ok(Self {
+            algorithm,
+            bytes: bytes.to_vec(),
+        })
+    }
+
+    /// The parameter set this key is for.
+    pub fn algorithm(&self) -> Algorithm {
+        self.algorithm
+    }
+
+    /// The raw FIPS 204 signing-key bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl MlDsaVerifyingKey {
+    /// Wrap raw ML-DSA verifying-key bytes for `algorithm`, checking the length matches the
+    /// parameter set. Errors with [VcError::KeyDecode] if `algorithm` is not ML-DSA or the
+    /// length is wrong.
+    pub fn new(algorithm: Algorithm, bytes: &[u8]) -> Result<Self, VcError> {
+        check_ml_dsa_key(algorithm, bytes.len(), false)?;
+        Ok(Self {
+            algorithm,
+            bytes: bytes.to_vec(),
+        })
+    }
+
+    /// The parameter set this key is for.
+    pub fn algorithm(&self) -> Algorithm {
+        self.algorithm
+    }
+
+    /// The raw FIPS 204 verifying-key bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+// Redact the secret in Debug output so it can't leak into logs (mirrors [SigningKey]).
+impl fmt::Debug for MlDsaSigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MlDsaSigningKey")
+            .field("algorithm", &self.algorithm)
+            .field("bytes", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// A typed ML-DSA key pair produced by [generate_ml_dsa_keypair].
+#[derive(Clone)]
+pub struct MlDsaKeyPair {
+    /// The private key used to sign credentials.
+    pub signing_key: MlDsaSigningKey,
+    /// The public key used to verify credentials.
+    pub verifying_key: MlDsaVerifyingKey,
+}
+
+/// Generate a typed [MlDsaKeyPair] for an ML-DSA parameter set (`MlDsa44` / `MlDsa65` /
+/// `MlDsa87`). Errors with [VcError::KeyDecode] if `algorithm` is [Algorithm::Ed25519] — use
+/// [generate_keypair] for that.
+pub fn generate_ml_dsa_keypair(algorithm: Algorithm) -> Result<MlDsaKeyPair, VcError> {
+    if algorithm.ml_dsa_key_lengths().is_none() {
+        return Err(VcError::KeyDecode(format!(
+            "{algorithm:?} is not an ML-DSA algorithm"
+        )));
+    }
+
+    let (private_key, public_key) = generate_keypair_bytes(algorithm);
+    Ok(MlDsaKeyPair {
+        signing_key: MlDsaSigningKey {
+            algorithm,
+            bytes: private_key,
+        },
+        verifying_key: MlDsaVerifyingKey {
+            algorithm,
+            bytes: public_key,
+        },
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,16 +267,22 @@ pub struct Proof {
 }
 
 impl Proof {
-    /// Construct a default EdDSA data-integrity proof carrying the given base64-encoded
-    /// `proofValue`. Uses the `eddsa-jcs-2022` cryptosuite, matching the JCS (RFC 8785)
-    /// canonicalization [signing](UnsignedVerifiableCredential::sign) applies.
-    fn new_eddsa_jcs_2022(proof_value: String) -> Self {
+    /// Construct a `DataIntegrityProof` for the given `cryptosuite`, carrying the
+    /// base64-encoded `proof_value`. This is the entry point for wrapping an
+    /// externally-computed signature (e.g. an ML-DSA signature produced out of process):
+    /// build the proof, attach it with [VerifiableCredential::from_parts], and the
+    /// credential serializes like any other.
+    ///
+    /// Defaults `proofPurpose` to `assertionMethod`; chain the `set_*` builders to
+    /// customize. The signature must be over the credential's
+    /// [signing_payload](UnsignedVerifiableCredential::signing_payload).
+    pub fn new_data_integrity(cryptosuite: &str, proof_value: String) -> Self {
         Proof {
             id: None,
             proof_type: "DataIntegrityProof".to_string(),
             proof_purpose: "assertionMethod".to_string(),
             verification_method: None,
-            cryptosuite: Some("eddsa-jcs-2022".to_string()),
+            cryptosuite: Some(cryptosuite.to_string()),
             created: None,
             expires: None,
             domain: None,
@@ -285,6 +291,11 @@ impl Proof {
             previous_proof: None,
             nonce: None,
         }
+    }
+
+    /// The base64-encoded `proofValue` (the raw signature bytes, base64-encoded).
+    pub fn proof_value(&self) -> &str {
+        &self.proof_value
     }
 
     /// Set the ID of the proof
@@ -350,6 +361,13 @@ impl Proof {
     /// Set the nonce of the proof
     pub fn set_nonce(mut self, nonce: Vec<String>) -> Self {
         self.nonce = Some(nonce);
+        self
+    }
+
+    /// Set the base64-encoded `proofValue`. Use this to inject an externally-computed
+    /// signature (e.g. ML-DSA signed out of process) into a proof.
+    pub fn set_proof_value(mut self, proof_value: String) -> Self {
+        self.proof_value = proof_value;
         self
     }
 }
@@ -439,20 +457,53 @@ impl UnsignedVerifiableCredential {
     /// survives a serialize/deserialize round-trip and is portable across
     /// implementations. Without it, the unordered `additional_properties` maps on
     /// `issuer`/`holder` objects would serialize inconsistently and break verification.
-    fn signing_payload(&self) -> Result<Vec<u8>, VcError> {
+    ///
+    /// Exposed so an external signer (e.g. an ML-DSA implementation in another process or
+    /// HSM) can sign exactly these bytes, then wrap the result with
+    /// [Proof::new_data_integrity] / [VerifiableCredential::from_parts].
+    pub fn signing_payload(&self) -> Result<Vec<u8>, VcError> {
         Ok(serde_jcs::to_vec(self)?)
     }
 
     /// Sign the Verifiable Credential with an Ed25519 [SigningKey], producing a
-    /// [VerifiableCredential] with a default proof and a computed `proofValue`.
+    /// [VerifiableCredential] with a default `eddsa-jcs-2022` proof. For other algorithms
+    /// use [sign_with_algorithm](UnsignedVerifiableCredential::sign_with_algorithm).
     ///
     /// This performs no schema validation; call
     /// [validate](UnsignedVerifiableCredential::validate) first if you need it.
     pub fn sign(self, signing_key: &SigningKey) -> Result<VerifiableCredential, VcError> {
-        let dalek_key = DalekSigningKey::from_bytes(&signing_key.0);
+        self.sign_with_algorithm(Algorithm::Ed25519, &signing_key.0)
+    }
+
+    /// Sign with the given [Algorithm] and a raw private key of the matching length
+    /// (Ed25519: 32-byte seed; ML-DSA: the FIPS 204 expanded signing key — 2560 / 4032 /
+    /// 4896 bytes for ML-DSA-44 / 65 / 87). The signature is taken over the JCS-canonical
+    /// credential and stored base64-encoded in a `DataIntegrityProof` whose `cryptosuite`
+    /// is [Algorithm::cryptosuite].
+    ///
+    /// ML-DSA signing is deterministic (FIPS 204 optional variant) with an empty context.
+    pub fn sign_with_algorithm(
+        self,
+        algorithm: Algorithm,
+        private_key: &[u8],
+    ) -> Result<VerifiableCredential, VcError> {
         let message = self.signing_payload()?;
-        let signature = dalek_key.sign(&message);
-        let proof = Proof::new_eddsa_jcs_2022(BASE64_STANDARD.encode(signature.to_bytes()));
+        let signature = match algorithm {
+            Algorithm::Ed25519 => {
+                let array: [u8; 32] = private_key
+                    .try_into()
+                    .map_err(|_| VcError::InvalidPrivateKeyLength)?;
+                DalekSigningKey::from_bytes(&array)
+                    .sign(&message)
+                    .to_bytes()
+                    .to_vec()
+            }
+            Algorithm::MlDsa44 => mldsa_sign::<ml_dsa::MlDsa44>(private_key, &message)?,
+            Algorithm::MlDsa65 => mldsa_sign::<ml_dsa::MlDsa65>(private_key, &message)?,
+            Algorithm::MlDsa87 => mldsa_sign::<ml_dsa::MlDsa87>(private_key, &message)?,
+        };
+        let proof =
+            Proof::new_data_integrity(algorithm.cryptosuite(), BASE64_STANDARD.encode(signature));
 
         Ok(VerifiableCredential {
             unsigned: self,
@@ -462,24 +513,21 @@ impl UnsignedVerifiableCredential {
 }
 
 impl VerifiableCredential {
+    /// Assemble a signed credential from an unsigned credential and a [Proof]. Use this to
+    /// attach an externally-computed proof (see [Proof::new_data_integrity]).
+    pub fn from_parts(unsigned: UnsignedVerifiableCredential, proof: Proof) -> Self {
+        Self { unsigned, proof }
+    }
+
     /// Removes the proof and returns the [UnsignedVerifiableCredential]
     pub fn to_unsigned(self) -> UnsignedVerifiableCredential {
         self.unsigned
     }
 
-    /// Validate the embedded `credentialSubject` against a [SchemaSource].
-    ///
-    /// Call this alongside [verify](VerifiableCredential::verify) when you need
-    /// schema validation, e.g. `vc.validate(&schema)?; vc.verify(key)?`.
-    pub fn validate(&self, schema: &SchemaSource) -> Result<(), VcError> {
-        self.unsigned.validate(schema)
-    }
-
-    /// Verifies the contents of a Verifiable Credential against a [VerifyingKey]
-    pub fn verify(&self, verifying_key: &VerifyingKey) -> Result<(), VcError> {
+    /// Reject the credential if the current time is outside its `validFrom`/`validUntil`
+    /// window. Shared by all verification entry points.
+    fn check_validity_period(&self) -> Result<(), VcError> {
         let now = Utc::now();
-
-        // Check if the current timestamp is within the validity period
         if let Some(valid_from) = self.unsigned.valid_from {
             if now < valid_from {
                 return Err(VcError::NotYetValid);
@@ -490,17 +538,185 @@ impl VerifiableCredential {
                 return Err(VcError::Expired);
             }
         }
+        Ok(())
+    }
+
+    /// Validate the embedded `credentialSubject` against a [SchemaSource].
+    ///
+    /// Call this alongside [verify](VerifiableCredential::verify) when you need
+    /// schema validation, e.g. `vc.validate(&schema)?; vc.verify(key)?`.
+    pub fn validate(&self, schema: &SchemaSource) -> Result<(), VcError> {
+        self.unsigned.validate(schema)
+    }
+
+    /// Verify an **Ed25519** credential against a typed [VerifyingKey]. Checks the validity
+    /// period, that the proof's `cryptosuite` is `eddsa-jcs-2022`, and the signature. For
+    /// other algorithms use [verify_with_algorithm](VerifiableCredential::verify_with_algorithm)
+    /// or [verify_auto](VerifiableCredential::verify_auto).
+    pub fn verify(&self, verifying_key: &VerifyingKey) -> Result<(), VcError> {
+        if let Some(suite) = self.proof.cryptosuite.as_deref() {
+            if Algorithm::from_cryptosuite(suite) != Some(Algorithm::Ed25519) {
+                return Err(VcError::UnsupportedCryptosuite(suite.to_string()));
+            }
+        }
+        self.verify_with_algorithm(Algorithm::Ed25519, &verifying_key.0)
+    }
+
+    /// Verify with an explicit [Algorithm] and a raw public key of the matching length
+    /// (Ed25519: 32 bytes; ML-DSA: the FIPS 204 public key — 1312 / 1952 / 2592 bytes for
+    /// ML-DSA-44 / 65 / 87). Checks the validity period and the signature; does **not**
+    /// require the proof's `cryptosuite` to match (the caller asserts the algorithm).
+    pub fn verify_with_algorithm(
+        &self,
+        algorithm: Algorithm,
+        public_key: &[u8],
+    ) -> Result<(), VcError> {
+        self.check_validity_period()?;
 
         let message = self.unsigned.signing_payload()?;
-        let proof_bytes = BASE64_STANDARD.decode(&self.proof.proof_value)?;
-        let signature = Signature::from_slice(&proof_bytes).map_err(VcError::MalformedSignature)?;
-        let dalek_key =
-            DalekVerifyingKey::from_bytes(&verifying_key.0).map_err(VcError::InvalidPublicKey)?;
+        let signature = BASE64_STANDARD.decode(&self.proof.proof_value)?;
 
-        dalek_key
-            .verify(&message, &signature)
-            .map_err(VcError::SignatureVerificationFailed)?;
+        match algorithm {
+            Algorithm::Ed25519 => {
+                let array: [u8; 32] = public_key.try_into().map_err(|_| {
+                    VcError::InvalidPublicKey("Ed25519 public key must be 32 bytes".to_string())
+                })?;
+                let sig = Signature::from_slice(&signature)
+                    .map_err(|e| VcError::MalformedSignature(e.to_string()))?;
+                DalekVerifyingKey::from_bytes(&array)
+                    .map_err(|e| VcError::InvalidPublicKey(e.to_string()))?
+                    .verify(&message, &sig)
+                    .map_err(|_| VcError::SignatureVerificationFailed)
+            }
+            Algorithm::MlDsa44 => mldsa_verify::<ml_dsa::MlDsa44>(public_key, &message, &signature),
+            Algorithm::MlDsa65 => mldsa_verify::<ml_dsa::MlDsa65>(public_key, &message, &signature),
+            Algorithm::MlDsa87 => mldsa_verify::<ml_dsa::MlDsa87>(public_key, &message, &signature),
+        }
+    }
+
+    /// Verify by reading the algorithm from the proof's `cryptosuite` and dispatching to
+    /// the right verifier — the caller supplies only the raw public key bytes. Returns
+    /// [VcError::UnsupportedCryptosuite] if the proof names a suite this library can't
+    /// verify.
+    pub fn verify_auto(&self, public_key: &[u8]) -> Result<(), VcError> {
+        let suite = self.proof.cryptosuite.as_deref().unwrap_or("");
+        let algorithm = Algorithm::from_cryptosuite(suite)
+            .ok_or_else(|| VcError::UnsupportedCryptosuite(suite.to_string()))?;
+        self.verify_with_algorithm(algorithm, public_key)
+    }
+}
+
+/// A signature algorithm the toolkit can sign and verify with.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Algorithm {
+    /// Ed25519 (EdDSA). 32-byte keys, `eddsa-jcs-2022` cryptosuite.
+    Ed25519,
+    /// ML-DSA-44 (FIPS 204, security category 2).
+    MlDsa44,
+    /// ML-DSA-65 (FIPS 204, security category 3).
+    MlDsa65,
+    /// ML-DSA-87 (FIPS 204, security category 5).
+    MlDsa87,
+}
+
+impl Algorithm {
+    /// The `cryptosuite` identifier written into a [Proof] signed with this algorithm.
+    ///
+    /// Ed25519 uses the standardized `eddsa-jcs-2022`. The ML-DSA identifiers are
+    /// **provisional and bilateral**: the W3C `vc-di-mldsa` cryptosuite is still a Working
+    /// Draft with no finalized identifier, so these strings are a private convention that
+    /// signing and verifying parties must agree on out of band (see the README). All use
+    /// JCS (RFC 8785) canonicalization.
+    pub fn cryptosuite(self) -> &'static str {
+        match self {
+            Algorithm::Ed25519 => "eddsa-jcs-2022",
+            Algorithm::MlDsa44 => "mldsa44-jcs-2025",
+            Algorithm::MlDsa65 => "mldsa65-jcs-2025",
+            Algorithm::MlDsa87 => "mldsa87-jcs-2025",
+        }
+    }
+
+    /// Map a proof `cryptosuite` identifier back to an [Algorithm], or `None` if the
+    /// identifier is not one this library implements.
+    pub fn from_cryptosuite(cryptosuite: &str) -> Option<Self> {
+        match cryptosuite {
+            "eddsa-jcs-2022" => Some(Algorithm::Ed25519),
+            "mldsa44-jcs-2025" => Some(Algorithm::MlDsa44),
+            "mldsa65-jcs-2025" => Some(Algorithm::MlDsa65),
+            "mldsa87-jcs-2025" => Some(Algorithm::MlDsa87),
+            _ => None,
+        }
+    }
+}
+
+/// Sign `message` with a raw FIPS 204 expanded ML-DSA signing key, returning the raw
+/// signature bytes. Deterministic variant, empty context.
+#[allow(deprecated)] // from_expanded: importing an external expanded key is the intent here
+fn mldsa_sign<P: ml_dsa::MlDsaParams>(sk_bytes: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
+    let encoded = ml_dsa::ExpandedSigningKeyBytes::<P>::try_from(sk_bytes)
+        .map_err(|_| VcError::KeyDecode("ML-DSA signing key has the wrong length".to_string()))?;
+    let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_expanded(&encoded);
+    let signature = signing_key
+        .sign_deterministic(message, b"")
+        .map_err(|_| VcError::KeyDecode("ML-DSA signing failed".to_string()))?;
+    Ok(signature.encode().to_vec())
+}
+
+/// Verify a raw ML-DSA signature over `message` with a raw FIPS 204 public key.
+fn mldsa_verify<P: ml_dsa::MlDsaParams>(
+    pk_bytes: &[u8],
+    message: &[u8],
+    signature: &[u8],
+) -> Result<(), VcError> {
+    let encoded_pk = ml_dsa::EncodedVerifyingKey::<P>::try_from(pk_bytes).map_err(|_| {
+        VcError::InvalidPublicKey("ML-DSA public key has the wrong length".to_string())
+    })?;
+    let verifying_key = ml_dsa::VerifyingKey::<P>::decode(&encoded_pk);
+
+    let encoded_sig = ml_dsa::EncodedSignature::<P>::try_from(signature).map_err(|_| {
+        VcError::MalformedSignature("ML-DSA signature has the wrong length".to_string())
+    })?;
+    let signature = ml_dsa::Signature::<P>::decode(&encoded_sig).ok_or_else(|| {
+        VcError::MalformedSignature("ML-DSA signature failed to decode".to_string())
+    })?;
+
+    if verifying_key.verify_with_context(message, b"", &signature) {
         Ok(())
+    } else {
+        Err(VcError::SignatureVerificationFailed)
+    }
+}
+
+/// Generate an ML-DSA key pair from a fresh random seed, returning
+/// `(expanded_signing_key_bytes, verifying_key_bytes)` in their FIPS 204 encodings.
+#[allow(deprecated)] // to_expanded: we intentionally export the expanded key form
+fn mldsa_generate<P: ml_dsa::MlDsaParams>() -> (Vec<u8>, Vec<u8>) {
+    use rand::RngCore;
+    let mut seed = [0u8; 32];
+    OsRng.fill_bytes(&mut seed);
+    let seed = ml_dsa::B32::try_from(&seed[..]).expect("seed is 32 bytes");
+    let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_seed(&seed);
+    (
+        signing_key.to_expanded().to_vec(),
+        signing_key.verifying_key().encode().to_vec(),
+    )
+}
+
+/// Generate a fresh key pair for `algorithm`, returning `(private_key, public_key)` as
+/// raw bytes suitable for [UnsignedVerifiableCredential::sign_with_algorithm] and
+/// [VerifiableCredential::verify_with_algorithm].
+pub fn generate_keypair_bytes(algorithm: Algorithm) -> (Vec<u8>, Vec<u8>) {
+    match algorithm {
+        Algorithm::Ed25519 => {
+            let signing_key = DalekSigningKey::generate(&mut OsRng);
+            (
+                signing_key.to_bytes().to_vec(),
+                signing_key.verifying_key().to_bytes().to_vec(),
+            )
+        }
+        Algorithm::MlDsa44 => mldsa_generate::<ml_dsa::MlDsa44>(),
+        Algorithm::MlDsa65 => mldsa_generate::<ml_dsa::MlDsa65>(),
+        Algorithm::MlDsa87 => mldsa_generate::<ml_dsa::MlDsa87>(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -591,4 +591,3 @@ impl VerifiableCredential {
         self.verify_with_algorithm(algorithm, public_key)
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,22 @@
 use chrono::{DateTime, Utc};
-use ed25519_dalek::{
-    Signature, Signer, SigningKey as DalekSigningKey, Verifier, VerifyingKey as DalekVerifyingKey,
-};
 use multibase::Base;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::formats::PreferOne;
 use serde_with::{serde_as, OneOrMany};
 use std::collections::HashMap;
-use std::fmt;
-use std::marker::PhantomData;
 use url::Url;
 
 pub mod bindings;
+pub mod crypto;
 pub mod error;
 pub mod proto_schemas;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
 
+pub use crypto::{
+    generate_keypair, generate_keypair_bytes, Algorithm, KeyPair, SigningKey, VerifyingKey,
+};
 pub use error::VcError;
 
 /// A Verifiable Credential as defined by the W3C Verifiable Credentials Data Model v2.0 - <https://www.w3.org/TR/vc-data-model-2.0> WITHOUT the proof
@@ -465,25 +464,16 @@ impl UnsignedVerifiableCredential {
         Ok(serde_jcs::to_vec(self)?)
     }
 
-    /// Sign the Verifiable Credential with an Ed25519 [SigningKey], producing a
-    /// [VerifiableCredential] with a default `eddsa-jcs-2022` proof. For other algorithms
-    /// use [sign_with_algorithm](UnsignedVerifiableCredential::sign_with_algorithm).
+    /// Sign the Verifiable Credential with a [SigningKey], producing a
+    /// [VerifiableCredential] with a `DataIntegrityProof`. The algorithm (and so the
+    /// proof's `cryptosuite`) is taken from the key, so the same call signs with Ed25519 or
+    /// any ML-DSA parameter set. For raw-byte interop use
+    /// [sign_with_algorithm](UnsignedVerifiableCredential::sign_with_algorithm).
     ///
     /// This performs no schema validation; call
     /// [validate](UnsignedVerifiableCredential::validate) first if you need it.
     pub fn sign(self, signing_key: &SigningKey) -> Result<VerifiableCredential, VcError> {
-        self.sign_with_algorithm(Algorithm::Ed25519, &signing_key.0)
-    }
-
-    /// Sign with a typed [MlDsaSigningKey]. The parameter set is taken from the key, so
-    /// (unlike [sign_with_algorithm](UnsignedVerifiableCredential::sign_with_algorithm)) the
-    /// algorithm and key can't disagree. The ML-DSA counterpart of
-    /// [sign](UnsignedVerifiableCredential::sign).
-    pub fn sign_ml_dsa(
-        self,
-        signing_key: &MlDsaSigningKey,
-    ) -> Result<VerifiableCredential, VcError> {
-        self.sign_with_algorithm(signing_key.algorithm, &signing_key.bytes)
+        self.sign_with_algorithm(signing_key.algorithm(), signing_key.as_bytes())
     }
 
     /// Sign with the given [Algorithm] and a raw private key of the matching length
@@ -500,7 +490,7 @@ impl UnsignedVerifiableCredential {
         private_key: &[u8],
     ) -> Result<VerifiableCredential, VcError> {
         let message = self.signing_payload()?;
-        let signature = algorithm.scheme().sign(private_key, &message)?;
+        let signature = crypto::sign_bytes(algorithm, private_key, &message)?;
         let proof = Proof::new_data_integrity(
             algorithm.cryptosuite(),
             multibase::encode(Base::Base58Btc, signature),
@@ -550,19 +540,22 @@ impl VerifiableCredential {
         self.unsigned.validate(schema)
     }
 
-    /// Verify an **Ed25519** credential against a typed [VerifyingKey]. Checks the validity
-    /// period, that the proof's `cryptosuite` is `eddsa-jcs-2022`, and the signature. A proof
-    /// that carries no `cryptosuite` is rejected ([VcError::MissingCryptosuite]) rather than
-    /// assumed to be Ed25519. For other algorithms use
-    /// [verify_with_algorithm](VerifiableCredential::verify_with_algorithm) or
+    /// Verify the credential against a typed [VerifyingKey]. Checks the validity period,
+    /// that the proof's `cryptosuite` names the same algorithm as the key (rejecting, e.g.,
+    /// an ML-DSA-87 proof under an ML-DSA-44 key, or an ML-DSA proof under an Ed25519 key),
+    /// and the signature. A proof that carries no `cryptosuite` is rejected with
+    /// [VcError::MissingCryptosuite] rather than assumed. The algorithm is taken from the
+    /// key, so this works for Ed25519 and every ML-DSA parameter set; for raw-byte interop
+    /// use [verify_with_algorithm](VerifiableCredential::verify_with_algorithm) or
     /// [verify_auto](VerifiableCredential::verify_auto).
     pub fn verify(&self, verifying_key: &VerifyingKey) -> Result<(), VcError> {
         match self.proof.cryptosuite.as_deref() {
-            Some(suite) if Algorithm::from_cryptosuite(suite) == Some(Algorithm::Ed25519) => {}
+            Some(suite)
+                if Algorithm::from_cryptosuite(suite) == Some(verifying_key.algorithm()) => {}
             Some(suite) => return Err(VcError::UnsupportedCryptosuite(suite.to_string())),
             None => return Err(VcError::MissingCryptosuite),
         }
-        self.verify_with_algorithm(Algorithm::Ed25519, &verifying_key.0)
+        self.verify_with_algorithm(verifying_key.algorithm(), verifying_key.as_bytes())
     }
 
     /// Verify with an explicit [Algorithm] and a raw public key of the matching length
@@ -580,7 +573,7 @@ impl VerifiableCredential {
         let (_, signature) = multibase::decode(&self.proof.proof_value)
             .map_err(|e| VcError::ProofDecode(e.to_string()))?;
 
-        algorithm.scheme().verify(public_key, &message, &signature)
+        crypto::verify_bytes(algorithm, public_key, &message, &signature)
     }
 
     /// Verify by reading the algorithm from the proof's `cryptosuite` and dispatching to
@@ -597,456 +590,5 @@ impl VerifiableCredential {
             .ok_or_else(|| VcError::UnsupportedCryptosuite(suite.to_string()))?;
         self.verify_with_algorithm(algorithm, public_key)
     }
-
-    /// Verify against a typed [MlDsaVerifyingKey]. Checks the validity period, that the
-    /// proof's `cryptosuite` matches the key's parameter set (rejecting, e.g., an ML-DSA-87
-    /// proof under an ML-DSA-44 key), and the signature. The ML-DSA counterpart of
-    /// [verify](VerifiableCredential::verify); a proof without a `cryptosuite` is rejected
-    /// with [VcError::MissingCryptosuite].
-    pub fn verify_ml_dsa(&self, verifying_key: &MlDsaVerifyingKey) -> Result<(), VcError> {
-        match self.proof.cryptosuite.as_deref() {
-            Some(suite) if Algorithm::from_cryptosuite(suite) == Some(verifying_key.algorithm) => {}
-            Some(suite) => return Err(VcError::UnsupportedCryptosuite(suite.to_string())),
-            None => return Err(VcError::MissingCryptosuite),
-        }
-        self.verify_with_algorithm(verifying_key.algorithm, &verifying_key.bytes)
-    }
 }
 
-/// A signature algorithm the toolkit can sign and verify with.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum Algorithm {
-    /// Ed25519 (EdDSA). 32-byte keys, `eddsa-jcs-2022` cryptosuite.
-    Ed25519,
-    /// ML-DSA-44 (FIPS 204, security category 2).
-    MlDsa44,
-    /// ML-DSA-65 (FIPS 204, security category 3).
-    MlDsa65,
-    /// ML-DSA-87 (FIPS 204, security category 5).
-    MlDsa87,
-}
-
-impl Algorithm {
-    /// The `cryptosuite` identifier written into a [Proof] signed with this algorithm.
-    ///
-    /// Ed25519 uses the standardized `eddsa-jcs-2022`. The ML-DSA identifiers are
-    /// **provisional and bilateral**: the W3C `vc-di-mldsa` cryptosuite is still a Working
-    /// Draft with no finalized identifier, so these strings are a private convention that
-    /// signing and verifying parties must agree on out of band (see the README). All use
-    /// JCS (RFC 8785) canonicalization.
-    pub fn cryptosuite(self) -> &'static str {
-        match self {
-            Algorithm::Ed25519 => "eddsa-jcs-2022",
-            Algorithm::MlDsa44 => "mldsa44-jcs-2025",
-            Algorithm::MlDsa65 => "mldsa65-jcs-2025",
-            Algorithm::MlDsa87 => "mldsa87-jcs-2025",
-        }
-    }
-
-    /// Map a proof `cryptosuite` identifier back to an [Algorithm], or `None` if the
-    /// identifier is not one this library implements.
-    pub fn from_cryptosuite(cryptosuite: &str) -> Option<Self> {
-        match cryptosuite {
-            "eddsa-jcs-2022" => Some(Algorithm::Ed25519),
-            "mldsa44-jcs-2025" => Some(Algorithm::MlDsa44),
-            "mldsa65-jcs-2025" => Some(Algorithm::MlDsa65),
-            "mldsa87-jcs-2025" => Some(Algorithm::MlDsa87),
-            _ => None,
-        }
-    }
-
-    /// The FIPS 204 raw key lengths `(private, public)` in bytes for this ML-DSA parameter
-    /// set, or `None` for non-ML-DSA algorithms. Used to length-check [MlDsaSigningKey] /
-    /// [MlDsaVerifyingKey] at construction. These sizes are fixed by FIPS 204 and pinned by
-    /// the `keypair_byte_lengths_match_wire_contract` test.
-    fn ml_dsa_key_lengths(self) -> Option<(usize, usize)> {
-        match self {
-            Algorithm::Ed25519 => None,
-            Algorithm::MlDsa44 => Some((2560, 1312)),
-            Algorithm::MlDsa65 => Some((4032, 1952)),
-            Algorithm::MlDsa87 => Some((4896, 2592)),
-        }
-    }
-
-    /// The single dispatch point from the runtime [Algorithm] tag to the compile-time
-    /// [SignatureScheme] that implements it. Every sign / verify / keygen call routes
-    /// through here, so this is the only place that enumerates the variants — adding an
-    /// algorithm means adding one arm here plus one trait impl.
-    fn scheme(self) -> Box<dyn SignatureScheme> {
-        match self {
-            Algorithm::Ed25519 => Box::new(Ed25519Scheme),
-            Algorithm::MlDsa44 => Box::new(MlDsaScheme::<ml_dsa::MlDsa44>(PhantomData)),
-            Algorithm::MlDsa65 => Box::new(MlDsaScheme::<ml_dsa::MlDsa65>(PhantomData)),
-            Algorithm::MlDsa87 => Box::new(MlDsaScheme::<ml_dsa::MlDsa87>(PhantomData)),
-        }
-    }
-}
-
-/// The per-algorithm signing operations, behind one interface. Implemented by a
-/// zero-sized marker per scheme ([Ed25519Scheme], [MlDsaScheme]) and selected at runtime
-/// by [Algorithm::scheme]. Keeping this internal means the public API stays the
-/// [Algorithm] enum and the methods on the credential; this trait only removes the
-/// duplicated `match` arms and provides the seam where a FIPS-validated / HSM backend can
-/// be dropped in as one extra impl.
-trait SignatureScheme {
-    /// Sign `message` with a raw private key of this scheme's expected length.
-    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError>;
-    /// Verify a raw `signature` over `message` with a raw public key.
-    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError>;
-    /// Generate a fresh key pair, returning `(private_key, public_key)` as raw bytes.
-    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>);
-}
-
-/// Ed25519 (EdDSA) over 32-byte keys.
-struct Ed25519Scheme;
-
-impl SignatureScheme for Ed25519Scheme {
-    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
-        let array: [u8; 32] = private_key
-            .try_into()
-            .map_err(|_| VcError::InvalidPrivateKeyLength)?;
-        Ok(DalekSigningKey::from_bytes(&array)
-            .sign(message)
-            .to_bytes()
-            .to_vec())
-    }
-
-    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError> {
-        let array: [u8; 32] = public_key.try_into().map_err(|_| {
-            VcError::InvalidPublicKey("Ed25519 public key must be 32 bytes".to_string())
-        })?;
-        let sig = Signature::from_slice(signature)
-            .map_err(|e| VcError::MalformedSignature(e.to_string()))?;
-        DalekVerifyingKey::from_bytes(&array)
-            .map_err(|e| VcError::InvalidPublicKey(e.to_string()))?
-            .verify(message, &sig)
-            .map_err(|_| VcError::SignatureVerificationFailed)
-    }
-
-    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>) {
-        let signing_key = DalekSigningKey::from_bytes(&random_seed());
-        (
-            signing_key.to_bytes().to_vec(),
-            signing_key.verifying_key().to_bytes().to_vec(),
-        )
-    }
-}
-
-/// ML-DSA (FIPS 204) for a given parameter set `P` (`MlDsa44` / `MlDsa65` / `MlDsa87`).
-/// Thin adapter over the `mldsa_*` helpers, which own the hedged-signing and
-/// panic-guard details.
-struct MlDsaScheme<P>(PhantomData<P>);
-
-impl<P: ml_dsa::MlDsaParams> SignatureScheme for MlDsaScheme<P> {
-    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
-        mldsa_sign::<P>(private_key, message)
-    }
-
-    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), VcError> {
-        mldsa_verify::<P>(public_key, message, signature)
-    }
-
-    fn generate_keypair(&self) -> (Vec<u8>, Vec<u8>) {
-        mldsa_generate::<P>()
-    }
-}
-
-/// Sign `message` with a raw FIPS 204 expanded ML-DSA signing key, returning the raw
-/// signature bytes. Uses the **hedged** (randomized) variant with an empty context, as
-/// recommended by FIPS 204 §3.4 — fresh randomness mitigates fault attacks and bad-RNG
-/// edge cases. Signatures are therefore non-deterministic (still verifiable by anyone).
-///
-/// `from_expanded` does not validate the key and can panic on a malformed (but
-/// correctly-sized) key. The private key is caller-supplied, so the whole sign is run
-/// inside `catch_unwind` and a panic is reported as a [VcError] rather than aborting.
-#[allow(deprecated)] // from_expanded: importing an external expanded key is the intent here
-fn mldsa_sign<P: ml_dsa::MlDsaParams>(sk_bytes: &[u8], message: &[u8]) -> Result<Vec<u8>, VcError> {
-    let encoded = ml_dsa::ExpandedSigningKeyBytes::<P>::try_from(sk_bytes)
-        .map_err(|_| VcError::KeyDecode("ML-DSA signing key has the wrong length".to_string()))?;
-
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_expanded(&encoded);
-        signing_key.sign_randomized(message, b"", &mut getrandom_v04::SysRng)
-    }))
-    .map_err(|_| VcError::KeyDecode("ML-DSA signing key is malformed".to_string()))?;
-
-    let signature = result.map_err(|_| VcError::KeyDecode("ML-DSA signing failed".to_string()))?;
-    Ok(signature.encode().to_vec())
-}
-
-/// Verify a raw ML-DSA signature over `message` with a raw FIPS 204 public key.
-fn mldsa_verify<P: ml_dsa::MlDsaParams>(
-    pk_bytes: &[u8],
-    message: &[u8],
-    signature: &[u8],
-) -> Result<(), VcError> {
-    let encoded_pk = ml_dsa::EncodedVerifyingKey::<P>::try_from(pk_bytes).map_err(|_| {
-        VcError::InvalidPublicKey("ML-DSA public key has the wrong length".to_string())
-    })?;
-    let verifying_key = ml_dsa::VerifyingKey::<P>::decode(&encoded_pk);
-
-    let encoded_sig = ml_dsa::EncodedSignature::<P>::try_from(signature).map_err(|_| {
-        VcError::MalformedSignature("ML-DSA signature has the wrong length".to_string())
-    })?;
-    let signature = ml_dsa::Signature::<P>::decode(&encoded_sig).ok_or_else(|| {
-        VcError::MalformedSignature("ML-DSA signature failed to decode".to_string())
-    })?;
-
-    if verifying_key.verify_with_context(message, b"", &signature) {
-        Ok(())
-    } else {
-        Err(VcError::SignatureVerificationFailed)
-    }
-}
-
-/// Fill a fresh 32-byte seed from the operating-system CSPRNG, accessed directly through
-/// `getrandom` — the same entropy source `rand::OsRng` wraps. Panics only if the OS RNG is
-/// unavailable, which is unrecoverable and matches the previous `OsRng`-based behavior.
-fn random_seed() -> [u8; 32] {
-    let mut seed = [0u8; 32];
-    getrandom_v04::fill(&mut seed).expect("operating-system RNG is unavailable");
-    seed
-}
-
-/// Generate an ML-DSA key pair from a fresh random seed, returning
-/// `(expanded_signing_key_bytes, verifying_key_bytes)` in their FIPS 204 encodings.
-#[allow(deprecated)] // to_expanded: we intentionally export the expanded key form
-fn mldsa_generate<P: ml_dsa::MlDsaParams>() -> (Vec<u8>, Vec<u8>) {
-    let seed = random_seed();
-    let seed = ml_dsa::B32::try_from(&seed[..]).expect("seed is 32 bytes");
-    let signing_key = ml_dsa::ExpandedSigningKey::<P>::from_seed(&seed);
-    (
-        signing_key.to_expanded().to_vec(),
-        signing_key.verifying_key().encode().to_vec(),
-    )
-}
-
-/// Generate a fresh key pair for `algorithm`, returning `(private_key, public_key)` as
-/// raw bytes suitable for [UnsignedVerifiableCredential::sign_with_algorithm] and
-/// [VerifiableCredential::verify_with_algorithm].
-pub fn generate_keypair_bytes(algorithm: Algorithm) -> (Vec<u8>, Vec<u8>) {
-    algorithm.scheme().generate_keypair()
-}
-
-/// A 32-byte Ed25519 private key, used to [sign](UnsignedVerifiableCredential::sign)
-/// credentials.
-///
-/// A distinct type from [VerifyingKey] so the two cannot be swapped by accident —
-/// passing a public key where a private key is expected (or vice versa) is a compile
-/// error rather than a silent runtime failure.
-#[derive(Clone)]
-pub struct SigningKey([u8; 32]);
-
-/// A 32-byte Ed25519 public key, used to [verify](VerifiableCredential::verify)
-/// credentials. See [SigningKey] for why this is a distinct type.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct VerifyingKey([u8; 32]);
-
-impl SigningKey {
-    /// Construct a signing key from exactly 32 bytes.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, VcError> {
-        let array: [u8; 32] = bytes
-            .try_into()
-            .map_err(|_| VcError::InvalidPrivateKeyLength)?;
-        Ok(Self(array))
-    }
-
-    /// The raw 32-byte representation of the key.
-    pub fn to_bytes(&self) -> [u8; 32] {
-        self.0
-    }
-}
-
-impl VerifyingKey {
-    /// Construct a verifying key from exactly 32 bytes.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, VcError> {
-        let array: [u8; 32] = bytes
-            .try_into()
-            .map_err(|_| VcError::InvalidPublicKeyLength)?;
-        Ok(Self(array))
-    }
-
-    /// The raw 32-byte representation of the key.
-    pub fn to_bytes(&self) -> [u8; 32] {
-        self.0
-    }
-}
-
-impl From<[u8; 32]> for SigningKey {
-    fn from(bytes: [u8; 32]) -> Self {
-        Self(bytes)
-    }
-}
-
-impl From<[u8; 32]> for VerifyingKey {
-    fn from(bytes: [u8; 32]) -> Self {
-        Self(bytes)
-    }
-}
-
-impl TryFrom<&[u8]> for SigningKey {
-    type Error = VcError;
-    fn try_from(bytes: &[u8]) -> Result<Self, VcError> {
-        Self::from_bytes(bytes)
-    }
-}
-
-impl TryFrom<&[u8]> for VerifyingKey {
-    type Error = VcError;
-    fn try_from(bytes: &[u8]) -> Result<Self, VcError> {
-        Self::from_bytes(bytes)
-    }
-}
-
-// Redact the secret in Debug output so it can't leak into logs.
-impl fmt::Debug for SigningKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("SigningKey([REDACTED])")
-    }
-}
-
-/// An Ed25519 key pair produced by [generate_keypair].
-#[derive(Clone)]
-pub struct KeyPair {
-    /// The private key used to sign credentials.
-    pub signing_key: SigningKey,
-    /// The public key used to verify credentials.
-    pub verifying_key: VerifyingKey,
-}
-
-/// Generate a new Ed25519 [KeyPair].
-pub fn generate_keypair() -> KeyPair {
-    let signing_key = DalekSigningKey::from_bytes(&random_seed());
-    let verifying_key = signing_key.verifying_key();
-
-    KeyPair {
-        signing_key: SigningKey(signing_key.to_bytes()),
-        verifying_key: VerifyingKey(verifying_key.to_bytes()),
-    }
-}
-
-/// An ML-DSA private (signing) key bundled with the parameter set it belongs to.
-///
-/// The ML-DSA analogue of [SigningKey]: the parameter set travels with the bytes, the
-/// length is checked against it at construction, and [sign_ml_dsa](UnsignedVerifiableCredential::sign_ml_dsa)
-/// reads the algorithm from the key — so a caller can't pass an ML-DSA-44 key to an
-/// ML-DSA-87 operation, or an ML-DSA key where a verify expects a different parameter set.
-/// For raw-byte interop (an HSM, the wasm ABI, a cross-language partner) use
-/// [sign_with_algorithm](UnsignedVerifiableCredential::sign_with_algorithm) with the raw
-/// key instead.
-#[derive(Clone)]
-pub struct MlDsaSigningKey {
-    algorithm: Algorithm,
-    bytes: Vec<u8>,
-}
-
-/// An ML-DSA public (verifying) key bundled with its parameter set. See [MlDsaSigningKey].
-#[derive(Clone, PartialEq, Eq)]
-pub struct MlDsaVerifyingKey {
-    algorithm: Algorithm,
-    bytes: Vec<u8>,
-}
-
-/// Validate that `algorithm` is an ML-DSA variant and that `len` matches its FIPS 204 key
-/// length (`private` selects which of the pair to check).
-fn check_ml_dsa_key(algorithm: Algorithm, len: usize, private: bool) -> Result<(), VcError> {
-    let (private_len, public_len) = algorithm
-        .ml_dsa_key_lengths()
-        .ok_or_else(|| VcError::KeyDecode(format!("{algorithm:?} is not an ML-DSA algorithm")))?;
-    let expected = if private { private_len } else { public_len };
-    if len != expected {
-        return Err(VcError::KeyDecode(format!(
-            "{algorithm:?} {} key must be {expected} bytes, got {len}",
-            if private { "signing" } else { "verifying" }
-        )));
-    }
-    Ok(())
-}
-
-impl MlDsaSigningKey {
-    /// Wrap raw ML-DSA signing-key bytes for `algorithm`, checking the length matches the
-    /// parameter set. Errors with [VcError::KeyDecode] if `algorithm` is not ML-DSA or the
-    /// length is wrong.
-    pub fn new(algorithm: Algorithm, bytes: &[u8]) -> Result<Self, VcError> {
-        check_ml_dsa_key(algorithm, bytes.len(), true)?;
-        Ok(Self {
-            algorithm,
-            bytes: bytes.to_vec(),
-        })
-    }
-
-    /// The parameter set this key is for.
-    pub fn algorithm(&self) -> Algorithm {
-        self.algorithm
-    }
-
-    /// The raw FIPS 204 signing-key bytes.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.bytes
-    }
-}
-
-impl MlDsaVerifyingKey {
-    /// Wrap raw ML-DSA verifying-key bytes for `algorithm`, checking the length matches the
-    /// parameter set. Errors with [VcError::KeyDecode] if `algorithm` is not ML-DSA or the
-    /// length is wrong.
-    pub fn new(algorithm: Algorithm, bytes: &[u8]) -> Result<Self, VcError> {
-        check_ml_dsa_key(algorithm, bytes.len(), false)?;
-        Ok(Self {
-            algorithm,
-            bytes: bytes.to_vec(),
-        })
-    }
-
-    /// The parameter set this key is for.
-    pub fn algorithm(&self) -> Algorithm {
-        self.algorithm
-    }
-
-    /// The raw FIPS 204 verifying-key bytes.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.bytes
-    }
-}
-
-// Redact the secret in Debug output so it can't leak into logs (mirrors [SigningKey]).
-impl fmt::Debug for MlDsaSigningKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("MlDsaSigningKey")
-            .field("algorithm", &self.algorithm)
-            .field("bytes", &"[REDACTED]")
-            .finish()
-    }
-}
-
-/// A typed ML-DSA key pair produced by [generate_ml_dsa_keypair].
-#[derive(Clone)]
-pub struct MlDsaKeyPair {
-    /// The private key used to sign credentials.
-    pub signing_key: MlDsaSigningKey,
-    /// The public key used to verify credentials.
-    pub verifying_key: MlDsaVerifyingKey,
-}
-
-/// Generate a typed [MlDsaKeyPair] for an ML-DSA parameter set (`MlDsa44` / `MlDsa65` /
-/// `MlDsa87`). Errors with [VcError::KeyDecode] if `algorithm` is [Algorithm::Ed25519] — use
-/// [generate_keypair] for that.
-pub fn generate_ml_dsa_keypair(algorithm: Algorithm) -> Result<MlDsaKeyPair, VcError> {
-    if algorithm.ml_dsa_key_lengths().is_none() {
-        return Err(VcError::KeyDecode(format!(
-            "{algorithm:?} is not an ML-DSA algorithm"
-        )));
-    }
-
-    let (private_key, public_key) = generate_keypair_bytes(algorithm);
-    Ok(MlDsaKeyPair {
-        signing_key: MlDsaSigningKey {
-            algorithm,
-            bytes: private_key,
-        },
-        verifying_key: MlDsaVerifyingKey {
-            algorithm,
-            bytes: public_key,
-        },
-    })
-}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -384,3 +384,50 @@ pub fn verify_cbor_vc(signed_vc_cbor: &[u8], public_key: &[u8]) -> Result<bool, 
         .map(|_| true)
         .map_err(|e| JsError::new(&format!("CBOR verification failed: {}", e)))
 }
+
+// multi-algorithm codec functions ------------------------------------------------------
+
+/// Sign an unsigned CBOR credential with the given algorithm label and raw private key.
+#[wasm_bindgen]
+pub fn sign_cbor_vc_with_algorithm(
+    unsigned_vc_cbor: &[u8],
+    algorithm: &str,
+    private_key: &[u8],
+) -> Result<Vec<u8>, JsError> {
+    crate::bindings::cbor::sign_cbor_vc_with_algorithm(
+        unsigned_vc_cbor,
+        parse_algorithm(algorithm)?,
+        private_key,
+    )
+    .map_err(|e| JsError::new(&format!("CBOR signing failed: {e}")))
+}
+
+/// Verify a signed CBOR credential, reading the algorithm from the proof's `cryptosuite`.
+#[wasm_bindgen]
+pub fn verify_cbor_vc_auto(signed_vc_cbor: &[u8], public_key: &[u8]) -> Result<bool, JsError> {
+    Ok(crate::bindings::cbor::verify_cbor_vc_auto(signed_vc_cbor, public_key).is_ok())
+}
+
+/// Sign an unsigned Protobuf credential with the given algorithm label and raw private key.
+#[wasm_bindgen]
+pub fn sign_protobuf_vc_with_algorithm(
+    unsigned_vc_protobuf: &[u8],
+    algorithm: &str,
+    private_key: &[u8],
+) -> Result<Vec<u8>, JsError> {
+    crate::bindings::protobuf::sign_protobuf_vc_with_algorithm(
+        unsigned_vc_protobuf,
+        parse_algorithm(algorithm)?,
+        private_key,
+    )
+    .map_err(|e| JsError::new(&format!("Protobuf signing failed: {e}")))
+}
+
+/// Verify a signed Protobuf credential, reading the algorithm from the proof's `cryptosuite`.
+#[wasm_bindgen]
+pub fn verify_protobuf_vc_auto(
+    signed_vc_protobuf: &[u8],
+    public_key: &[u8],
+) -> Result<bool, JsError> {
+    Ok(crate::bindings::protobuf::verify_protobuf_vc_auto(signed_vc_protobuf, public_key).is_ok())
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,7 +1,7 @@
 use crate::bindings::{cbor::Cbor, protobuf::Protobuf, CredentialCodec};
 use crate::UnsignedVerifiableCredential;
 use crate::VerifiableCredential;
-use crate::{SchemaSource, SigningKey, VerifyingKey};
+use crate::{generate_keypair_bytes, Algorithm, SchemaSource, SigningKey, VerifyingKey};
 use js_sys::{Array, Reflect};
 use serde::Serialize;
 use serde_wasm_bindgen::from_value;
@@ -200,7 +200,7 @@ impl KeyPair {
     }
 }
 
-/// Generate a new keypair
+/// Generate a new Ed25519 keypair
 #[wasm_bindgen]
 pub fn generate_keypair() -> KeyPair {
     let keypair = crate::generate_keypair();
@@ -208,6 +208,76 @@ pub fn generate_keypair() -> KeyPair {
         keypair.signing_key.to_bytes().to_vec(),
         keypair.verifying_key.to_bytes().to_vec(),
     )
+}
+
+/// Parse an algorithm label ("Ed25519", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87";
+/// case- and separator-insensitive) into an [Algorithm].
+fn parse_algorithm(label: &str) -> Result<Algorithm, JsError> {
+    match label
+        .to_ascii_lowercase()
+        .replace(['-', '_', ' '], "")
+        .as_str()
+    {
+        "ed25519" => Ok(Algorithm::Ed25519),
+        "mldsa44" => Ok(Algorithm::MlDsa44),
+        "mldsa65" => Ok(Algorithm::MlDsa65),
+        "mldsa87" => Ok(Algorithm::MlDsa87),
+        _ => Err(JsError::new(&format!("unknown algorithm: {label}"))),
+    }
+}
+
+/// Generate a key pair for the given algorithm label, returning raw key bytes
+/// (Ed25519 or ML-DSA-44/65/87 in their FIPS 204 encodings).
+#[wasm_bindgen]
+pub fn generate_keypair_for(algorithm: &str) -> Result<KeyPair, JsError> {
+    let (private_key, public_key) = generate_keypair_bytes(parse_algorithm(algorithm)?);
+    Ok(KeyPair::new(private_key, public_key))
+}
+
+/// Sign an unsigned credential (JS object) with the given algorithm and a raw private key
+/// of the matching length (Ed25519: 32 bytes; ML-DSA: the FIPS 204 expanded signing key).
+#[wasm_bindgen]
+pub fn sign_with_algorithm(
+    unsigned_vc: JsValue,
+    algorithm: &str,
+    private_key: &[u8],
+) -> Result<JsValue, JsError> {
+    let unsigned = unsigned_vc_from_js(&unsigned_vc)?;
+    let signed = unsigned
+        .sign_with_algorithm(parse_algorithm(algorithm)?, private_key)
+        .map_err(|e| JsError::new(&format!("Signing failed: {e}")))?;
+    Ok(to_js_value(&signed)?)
+}
+
+/// Verify a signed credential (JS object) with an explicit algorithm and a raw public key.
+/// Returns false on any failure.
+#[wasm_bindgen]
+pub fn verify_with_algorithm(
+    signed_vc: JsValue,
+    algorithm: &str,
+    public_key: &[u8],
+) -> Result<bool, JsError> {
+    let vc: VerifiableCredential = from_value(signed_vc).map_err(|e| {
+        JsError::new(&format!(
+            "Failed to deserialize signed verifiable credential: {e}"
+        ))
+    })?;
+    Ok(vc
+        .verify_with_algorithm(parse_algorithm(algorithm)?, public_key)
+        .is_ok())
+}
+
+/// Verify a signed credential (JS object), reading the algorithm from the proof's
+/// `cryptosuite`. The caller supplies only the raw public key bytes. Returns false on any
+/// failure (including an unsupported cryptosuite).
+#[wasm_bindgen]
+pub fn verify_auto(signed_vc: JsValue, public_key: &[u8]) -> Result<bool, JsError> {
+    let vc: VerifiableCredential = from_value(signed_vc).map_err(|e| {
+        JsError::new(&format!(
+            "Failed to deserialize signed verifiable credential: {e}"
+        ))
+    })?;
+    Ok(vc.verify_auto(public_key).is_ok())
 }
 
 // protobuf encoding/decoding functions --------------------------------------------------------

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -123,7 +123,7 @@ pub fn normalize_and_stringify(input: &JsValue) -> Result<String, JsError> {
 pub fn sign(unsigned_vc: JsValue, private_key: &[u8]) -> Result<JsValue, JsError> {
     let unsigned = unsigned_vc_from_js(&unsigned_vc)?;
 
-    let signing_key = SigningKey::from_bytes(private_key)
+    let signing_key = SigningKey::new(Algorithm::Ed25519, private_key)
         .map_err(|e| JsError::new(&format!("Invalid private key: {}", e)))?;
     let signed = unsigned
         .sign(&signing_key)
@@ -141,7 +141,7 @@ pub fn verify(signed_vc: JsValue, public_key: &[u8]) -> Result<bool, JsError> {
         ))
     })?;
 
-    let Ok(verifying_key) = VerifyingKey::from_bytes(public_key) else {
+    let Ok(verifying_key) = VerifyingKey::new(Algorithm::Ed25519, public_key) else {
         return Ok(false);
     };
     match vc.verify(&verifying_key) {
@@ -167,7 +167,7 @@ pub fn verify_with_schema_check(
     if vc.validate(&SchemaSource::Inline(&schema_value)).is_err() {
         return Ok(false);
     }
-    let Ok(verifying_key) = VerifyingKey::from_bytes(public_key) else {
+    let Ok(verifying_key) = VerifyingKey::new(Algorithm::Ed25519, public_key) else {
         return Ok(false);
     };
     match vc.verify(&verifying_key) {
@@ -203,11 +203,8 @@ impl KeyPair {
 /// Generate a new Ed25519 keypair
 #[wasm_bindgen]
 pub fn generate_keypair() -> KeyPair {
-    let keypair = crate::generate_keypair();
-    KeyPair::new(
-        keypair.signing_key.to_bytes().to_vec(),
-        keypair.verifying_key.to_bytes().to_vec(),
-    )
+    let (signing_key, verifying_key) = generate_keypair_bytes(Algorithm::Ed25519);
+    KeyPair::new(signing_key, verifying_key)
 }
 
 /// Parse an algorithm label ("Ed25519", "ML-DSA-44", "ML-DSA-65", "ML-DSA-87";

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -286,7 +286,7 @@ pub fn verify_auto(signed_vc: JsValue, public_key: &[u8]) -> Result<bool, JsErro
 #[wasm_bindgen]
 pub fn encode_unsigned_vc_to_protobuf(unsigned_vc: JsValue) -> Result<Vec<u8>, JsError> {
     let unsigned = unsigned_vc_from_js(&unsigned_vc)?;
-    crate::bindings::protobuf::encode_unsigned_vc_to_protobuf(&unsigned)
+    Protobuf::encode_unsigned(&unsigned)
         .map_err(|e| JsError::new(&format!("Protobuf encoding failed: {e}")))
 }
 
@@ -294,7 +294,7 @@ pub fn encode_unsigned_vc_to_protobuf(unsigned_vc: JsValue) -> Result<Vec<u8>, J
 #[wasm_bindgen]
 pub fn encode_signed_vc_to_protobuf(signed_vc: JsValue) -> Result<Vec<u8>, JsError> {
     let signed = signed_vc_from_js(&signed_vc)?;
-    crate::bindings::protobuf::encode_signed_vc_to_protobuf(&signed)
+    Protobuf::encode_signed(&signed)
         .map_err(|e| JsError::new(&format!("Protobuf encoding failed: {e}")))
 }
 
@@ -319,19 +319,15 @@ pub fn sign_protobuf_vc(
     unsigned_vc_protobuf: &[u8],
     private_key: &[u8],
 ) -> Result<Vec<u8>, JsError> {
-    let signing_key = SigningKey::from_bytes(private_key)
-        .map_err(|e| JsError::new(&format!("Invalid private key: {}", e)))?;
-    crate::bindings::protobuf::sign_protobuf_vc(unsigned_vc_protobuf, &signing_key)
-        .map_err(|e| JsError::new(&format!("Protobuf signing failed: {}", e)))
+    Protobuf::sign(unsigned_vc_protobuf, Algorithm::Ed25519, private_key)
+        .map_err(|e| JsError::new(&format!("Protobuf signing failed: {e}")))
 }
 
 #[wasm_bindgen]
 pub fn verify_protobuf_vc(signed_vc_protobuf: &[u8], public_key: &[u8]) -> Result<bool, JsError> {
-    let verifying_key = VerifyingKey::from_bytes(public_key)
-        .map_err(|e| JsError::new(&format!("Invalid public key: {}", e)))?;
-    crate::bindings::protobuf::verify_protobuf_vc(signed_vc_protobuf, &verifying_key)
+    Protobuf::verify(signed_vc_protobuf, Algorithm::Ed25519, public_key)
         .map(|_| true)
-        .map_err(|e| JsError::new(&format!("Protobuf verification failed: {}", e)))
+        .map_err(|e| JsError::new(&format!("Protobuf verification failed: {e}")))
 }
 
 // cbor encoding/decoding functions --------------------------------------------------------
@@ -340,7 +336,7 @@ pub fn verify_protobuf_vc(signed_vc_protobuf: &[u8], public_key: &[u8]) -> Resul
 #[wasm_bindgen]
 pub fn encode_unsigned_vc_to_cbor(unsigned_vc: JsValue) -> Result<Vec<u8>, JsError> {
     let unsigned = unsigned_vc_from_js(&unsigned_vc)?;
-    crate::bindings::cbor::encode_unsigned_vc_to_cbor(&unsigned)
+    Cbor::encode_unsigned(&unsigned)
         .map_err(|e| JsError::new(&format!("CBOR encoding failed: {e}")))
 }
 
@@ -348,8 +344,7 @@ pub fn encode_unsigned_vc_to_cbor(unsigned_vc: JsValue) -> Result<Vec<u8>, JsErr
 #[wasm_bindgen]
 pub fn encode_signed_vc_to_cbor(signed_vc: JsValue) -> Result<Vec<u8>, JsError> {
     let signed = signed_vc_from_js(&signed_vc)?;
-    crate::bindings::cbor::encode_signed_vc_to_cbor(&signed)
-        .map_err(|e| JsError::new(&format!("CBOR encoding failed: {e}")))
+    Cbor::encode_signed(&signed).map_err(|e| JsError::new(&format!("CBOR encoding failed: {e}")))
 }
 
 /// Decode CBOR bytes into an unsigned credential (JS object).
@@ -370,19 +365,15 @@ pub fn decode_signed_vc_from_cbor(signed_vc_cbor: &[u8]) -> Result<JsValue, JsEr
 
 #[wasm_bindgen]
 pub fn sign_cbor_vc(unsigned_vc_cbor: &[u8], private_key: &[u8]) -> Result<Vec<u8>, JsError> {
-    let signing_key = SigningKey::from_bytes(private_key)
-        .map_err(|e| JsError::new(&format!("Invalid private key: {}", e)))?;
-    crate::bindings::cbor::sign_cbor_vc(unsigned_vc_cbor, &signing_key)
-        .map_err(|e| JsError::new(&format!("CBOR signing failed: {}", e)))
+    Cbor::sign(unsigned_vc_cbor, Algorithm::Ed25519, private_key)
+        .map_err(|e| JsError::new(&format!("CBOR signing failed: {e}")))
 }
 
 #[wasm_bindgen]
 pub fn verify_cbor_vc(signed_vc_cbor: &[u8], public_key: &[u8]) -> Result<bool, JsError> {
-    let verifying_key = VerifyingKey::from_bytes(public_key)
-        .map_err(|e| JsError::new(&format!("Invalid public key: {}", e)))?;
-    crate::bindings::cbor::verify_cbor_vc(signed_vc_cbor, &verifying_key)
+    Cbor::verify(signed_vc_cbor, Algorithm::Ed25519, public_key)
         .map(|_| true)
-        .map_err(|e| JsError::new(&format!("CBOR verification failed: {}", e)))
+        .map_err(|e| JsError::new(&format!("CBOR verification failed: {e}")))
 }
 
 // multi-algorithm codec functions ------------------------------------------------------
@@ -394,18 +385,14 @@ pub fn sign_cbor_vc_with_algorithm(
     algorithm: &str,
     private_key: &[u8],
 ) -> Result<Vec<u8>, JsError> {
-    crate::bindings::cbor::sign_cbor_vc_with_algorithm(
-        unsigned_vc_cbor,
-        parse_algorithm(algorithm)?,
-        private_key,
-    )
-    .map_err(|e| JsError::new(&format!("CBOR signing failed: {e}")))
+    Cbor::sign(unsigned_vc_cbor, parse_algorithm(algorithm)?, private_key)
+        .map_err(|e| JsError::new(&format!("CBOR signing failed: {e}")))
 }
 
 /// Verify a signed CBOR credential, reading the algorithm from the proof's `cryptosuite`.
 #[wasm_bindgen]
 pub fn verify_cbor_vc_auto(signed_vc_cbor: &[u8], public_key: &[u8]) -> Result<bool, JsError> {
-    Ok(crate::bindings::cbor::verify_cbor_vc_auto(signed_vc_cbor, public_key).is_ok())
+    Ok(Cbor::verify_auto(signed_vc_cbor, public_key).is_ok())
 }
 
 /// Sign an unsigned Protobuf credential with the given algorithm label and raw private key.
@@ -415,7 +402,7 @@ pub fn sign_protobuf_vc_with_algorithm(
     algorithm: &str,
     private_key: &[u8],
 ) -> Result<Vec<u8>, JsError> {
-    crate::bindings::protobuf::sign_protobuf_vc_with_algorithm(
+    Protobuf::sign(
         unsigned_vc_protobuf,
         parse_algorithm(algorithm)?,
         private_key,
@@ -429,5 +416,5 @@ pub fn verify_protobuf_vc_auto(
     signed_vc_protobuf: &[u8],
     public_key: &[u8],
 ) -> Result<bool, JsError> {
-    Ok(crate::bindings::protobuf::verify_protobuf_vc_auto(signed_vc_protobuf, public_key).is_ok())
+    Ok(Protobuf::verify_auto(signed_vc_protobuf, public_key).is_ok())
 }

--- a/tests/bindings.rs
+++ b/tests/bindings.rs
@@ -5,16 +5,19 @@ use verifiable_credential_toolkit::{
     bindings::{
         cbor::{
             decode_signed_vc_from_cbor, decode_unsigned_vc_from_cbor, encode_signed_vc_to_cbor,
-            sign_cbor_vc, verify_cbor_vc, Cbor,
+            sign_cbor_vc, sign_cbor_vc_with_algorithm, verify_cbor_vc, verify_cbor_vc_auto,
+            verify_cbor_vc_with_algorithm, Cbor,
         },
         protobuf::{
             decode_signed_vc_from_protobuf, decode_unsigned_vc_from_protobuf,
             encode_signed_vc_to_protobuf, encode_unsigned_vc_to_protobuf, sign_protobuf_vc,
-            verify_protobuf_vc, Protobuf,
+            sign_protobuf_vc_with_algorithm, verify_protobuf_vc, verify_protobuf_vc_auto,
+            verify_protobuf_vc_with_algorithm, Protobuf,
         },
         CredentialCodec,
     },
-    SigningKey, UnsignedVerifiableCredential, VcError, VerifiableCredential, VerifyingKey,
+    generate_keypair_bytes, Algorithm, SigningKey, UnsignedVerifiableCredential, VcError,
+    VerifiableCredential, VerifyingKey,
 };
 
 fn load_private_key() -> SigningKey {
@@ -492,4 +495,70 @@ fn signing_is_stable_for_object_issuer_with_extra_properties() {
         let cbor = encode_signed_vc_to_cbor(&signed).expect("cbor encode failed");
         verify_cbor_vc(&cbor, &public_key).expect("cbor verification after round-trip");
     }
+}
+
+// --- ML-DSA over CBOR and Protobuf, and cross-format interop ------------------
+
+/// Every supported algorithm signs and verifies through both codecs (verify_auto reads
+/// the cryptosuite; verify_with_algorithm is explicit).
+#[test]
+fn all_algorithms_sign_verify_via_cbor_and_protobuf() {
+    for algorithm in [
+        Algorithm::Ed25519,
+        Algorithm::MlDsa44,
+        Algorithm::MlDsa65,
+        Algorithm::MlDsa87,
+    ] {
+        let (private_key, public_key) = generate_keypair_bytes(algorithm);
+
+        // CBOR
+        let unsigned_cbor = to_vec(&sample_unsigned_vc()).expect("cbor encode unsigned");
+        let signed_cbor = sign_cbor_vc_with_algorithm(&unsigned_cbor, algorithm, &private_key)
+            .unwrap_or_else(|e| panic!("cbor sign failed for {algorithm:?}: {e}"));
+        verify_cbor_vc_auto(&signed_cbor, &public_key)
+            .unwrap_or_else(|e| panic!("cbor verify_auto failed for {algorithm:?}: {e}"));
+        verify_cbor_vc_with_algorithm(&signed_cbor, algorithm, &public_key)
+            .unwrap_or_else(|e| panic!("cbor verify_with_algorithm failed for {algorithm:?}: {e}"));
+
+        // Protobuf
+        let unsigned_pb = encode_unsigned_vc_to_protobuf(&sample_unsigned_vc())
+            .expect("protobuf encode unsigned");
+        let signed_pb = sign_protobuf_vc_with_algorithm(&unsigned_pb, algorithm, &private_key)
+            .unwrap_or_else(|e| panic!("protobuf sign failed for {algorithm:?}: {e}"));
+        verify_protobuf_vc_auto(&signed_pb, &public_key)
+            .unwrap_or_else(|e| panic!("protobuf verify_auto failed for {algorithm:?}: {e}"));
+        verify_protobuf_vc_with_algorithm(&signed_pb, algorithm, &public_key).unwrap_or_else(|e| {
+            panic!("protobuf verify_with_algorithm failed for {algorithm:?}: {e}")
+        });
+    }
+}
+
+/// The signature is over the format-independent JCS canonical form, so an ML-DSA
+/// credential signed in one representation verifies in every other — the interop
+/// guarantee. Sign via the JSON core, then verify the same credential as CBOR and as
+/// Protobuf; and sign via CBOR, then verify after transcoding to Protobuf.
+#[test]
+fn mldsa_signature_is_interoperable_across_formats() {
+    let (private_key, public_key) = generate_keypair_bytes(Algorithm::MlDsa65);
+
+    // Signed once via the core JSON path.
+    let signed = sample_unsigned_vc()
+        .sign_with_algorithm(Algorithm::MlDsa65, &private_key)
+        .expect("core sign");
+
+    // Verifies as CBOR and as Protobuf.
+    let cbor = encode_signed_vc_to_cbor(&signed).expect("cbor encode");
+    verify_cbor_vc_auto(&cbor, &public_key).expect("verify cbor");
+    let protobuf = encode_signed_vc_to_protobuf(&signed).expect("protobuf encode");
+    verify_protobuf_vc_auto(&protobuf, &public_key).expect("verify protobuf");
+
+    // Signed via the CBOR pipeline, transcoded to Protobuf, still verifies.
+    let unsigned_cbor = to_vec(&sample_unsigned_vc()).expect("cbor encode unsigned");
+    let signed_cbor = sign_cbor_vc_with_algorithm(&unsigned_cbor, Algorithm::MlDsa65, &private_key)
+        .expect("cbor sign");
+    let transcoded = encode_signed_vc_to_protobuf(
+        &decode_signed_vc_from_cbor(&signed_cbor).expect("decode cbor"),
+    )
+    .expect("re-encode protobuf");
+    verify_protobuf_vc_auto(&transcoded, &public_key).expect("verify transcoded");
 }

--- a/tests/bindings.rs
+++ b/tests/bindings.rs
@@ -7,7 +7,8 @@ use verifiable_credential_toolkit::{
 };
 
 fn load_private_key() -> SigningKey {
-    SigningKey::from_bytes(
+    SigningKey::new(
+        Algorithm::Ed25519,
         &std::fs::read("tests/test_data/keys/key.priv")
             .expect("Error reading private key from file"),
     )
@@ -15,7 +16,8 @@ fn load_private_key() -> SigningKey {
 }
 
 fn load_public_key() -> VerifyingKey {
-    VerifyingKey::from_bytes(
+    VerifyingKey::new(
+        Algorithm::Ed25519,
         &std::fs::read("tests/test_data/keys/key.pub").expect("Error reading public key from file"),
     )
     .expect("Invalid public key")
@@ -75,10 +77,10 @@ fn cbor_sign_and_verify_roundtrip() {
 
     let unsigned_bytes =
         Cbor::encode_unsigned(&sample_unsigned_vc()).expect("Failed to encode unsigned VC");
-    let signed_bytes = Cbor::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key.to_bytes())
+    let signed_bytes = Cbor::sign(&unsigned_bytes, Algorithm::Ed25519, private_key.as_bytes())
         .expect("CBOR signing failed");
 
-    Cbor::verify(&signed_bytes, Algorithm::Ed25519, &public_key.to_bytes())
+    Cbor::verify(&signed_bytes, Algorithm::Ed25519, public_key.as_bytes())
         .expect("CBOR verification failed");
 }
 
@@ -92,7 +94,7 @@ fn cbor_encode_decode_signed_roundtrip() {
     let decoded_vc = Cbor::decode_signed(&cbor_bytes).expect("Failed to decode signed VC");
 
     assert_eq!(signed_vc, decoded_vc);
-    Cbor::verify(&cbor_bytes, Algorithm::Ed25519, &public_key.to_bytes())
+    Cbor::verify(&cbor_bytes, Algorithm::Ed25519, public_key.as_bytes())
         .expect("CBOR verification failed");
 }
 
@@ -111,14 +113,14 @@ fn cbor_verify_rejects_tampered_payload() {
 
     let unsigned_bytes =
         Cbor::encode_unsigned(&sample_unsigned_vc()).expect("Failed to encode unsigned VC");
-    let mut signed_bytes = Cbor::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key.to_bytes())
+    let mut signed_bytes = Cbor::sign(&unsigned_bytes, Algorithm::Ed25519, private_key.as_bytes())
         .expect("CBOR signing failed");
 
     assert!(!signed_bytes.is_empty());
     let idx = signed_bytes.len() / 2;
     signed_bytes[idx] ^= 0x01;
 
-    assert!(Cbor::verify(&signed_bytes, Algorithm::Ed25519, &public_key.to_bytes()).is_err());
+    assert!(Cbor::verify(&signed_bytes, Algorithm::Ed25519, public_key.as_bytes()).is_err());
 }
 
 #[test]
@@ -127,10 +129,10 @@ fn protobuf_sign_and_verify_roundtrip() {
     let public_key = load_public_key();
 
     let unsigned_bytes = unsigned_vc_to_protobuf_bytes(&sample_unsigned_vc());
-    let signed_bytes = Protobuf::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key.to_bytes())
+    let signed_bytes = Protobuf::sign(&unsigned_bytes, Algorithm::Ed25519, private_key.as_bytes())
         .expect("Protobuf signing failed");
 
-    Protobuf::verify(&signed_bytes, Algorithm::Ed25519, &public_key.to_bytes())
+    Protobuf::verify(&signed_bytes, Algorithm::Ed25519, public_key.as_bytes())
         .expect("Protobuf verification failed");
 }
 
@@ -148,7 +150,7 @@ fn protobuf_encode_and_verify_roundtrip() {
         .expect("Failed to decode signed VC into domain type");
     assert_eq!(signed_vc, decoded);
 
-    Protobuf::verify(&protobuf_bytes, Algorithm::Ed25519, &public_key.to_bytes())
+    Protobuf::verify(&protobuf_bytes, Algorithm::Ed25519, public_key.as_bytes())
         .expect("Protobuf verification failed");
 }
 
@@ -185,14 +187,14 @@ fn protobuf_verify_rejects_tampered_payload() {
 
     let unsigned_bytes = unsigned_vc_to_protobuf_bytes(&sample_unsigned_vc());
     let mut signed_bytes =
-        Protobuf::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key.to_bytes())
+        Protobuf::sign(&unsigned_bytes, Algorithm::Ed25519, private_key.as_bytes())
             .expect("Protobuf signing failed");
 
     assert!(!signed_bytes.is_empty());
     let idx = signed_bytes.len() / 2;
     signed_bytes[idx] ^= 0x01;
 
-    assert!(Protobuf::verify(&signed_bytes, Algorithm::Ed25519, &public_key.to_bytes()).is_err());
+    assert!(Protobuf::verify(&signed_bytes, Algorithm::Ed25519, public_key.as_bytes()).is_err());
 }
 
 // --- Number fidelity through each codec ---------------------------------------
@@ -329,9 +331,9 @@ fn protobuf_full_credential_signs_and_verifies() {
         serde_json::from_value(kitchen_sink_unsigned_json()).expect("kitchen-sink should parse");
     let unsigned_bytes = Protobuf::encode_unsigned(&vc).expect("encode failed");
 
-    let signed_bytes = Protobuf::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key.to_bytes())
+    let signed_bytes = Protobuf::sign(&unsigned_bytes, Algorithm::Ed25519, private_key.as_bytes())
         .expect("signing failed");
-    Protobuf::verify(&signed_bytes, Algorithm::Ed25519, &public_key.to_bytes())
+    Protobuf::verify(&signed_bytes, Algorithm::Ed25519, public_key.as_bytes())
         .expect("verification failed");
 
     let decoded = Protobuf::decode_signed(&signed_bytes).expect("decode failed");
@@ -436,7 +438,7 @@ fn signature_is_independent_of_codec() {
 
     // Protobuf transport.
     let pb = Protobuf::encode_signed(&signed).expect("protobuf encode failed");
-    Protobuf::verify(&pb, Algorithm::Ed25519, &public_key.to_bytes())
+    Protobuf::verify(&pb, Algorithm::Ed25519, public_key.as_bytes())
         .expect("protobuf verification failed");
     assert_eq!(
         Protobuf::decode_signed(&pb).expect("protobuf decode"),
@@ -445,7 +447,7 @@ fn signature_is_independent_of_codec() {
 
     // CBOR transport.
     let cbor = Cbor::encode_signed(&signed).expect("cbor encode failed");
-    Cbor::verify(&cbor, Algorithm::Ed25519, &public_key.to_bytes())
+    Cbor::verify(&cbor, Algorithm::Ed25519, public_key.as_bytes())
         .expect("cbor verification failed");
     assert_eq!(Cbor::decode_signed(&cbor).expect("cbor decode"), signed);
 }
@@ -480,11 +482,11 @@ fn signing_is_stable_for_object_issuer_with_extra_properties() {
         let signed = unsigned.sign(&private_key).expect("signing failed");
 
         let pb = Protobuf::encode_signed(&signed).expect("protobuf encode failed");
-        Protobuf::verify(&pb, Algorithm::Ed25519, &public_key.to_bytes())
+        Protobuf::verify(&pb, Algorithm::Ed25519, public_key.as_bytes())
             .expect("protobuf verification after round-trip");
 
         let cbor = Cbor::encode_signed(&signed).expect("cbor encode failed");
-        Cbor::verify(&cbor, Algorithm::Ed25519, &public_key.to_bytes())
+        Cbor::verify(&cbor, Algorithm::Ed25519, public_key.as_bytes())
             .expect("cbor verification after round-trip");
     }
 }

--- a/tests/bindings.rs
+++ b/tests/bindings.rs
@@ -1,21 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use c2pa_cbor::to_vec;
 use verifiable_credential_toolkit::{
-    bindings::{
-        cbor::{
-            decode_signed_vc_from_cbor, decode_unsigned_vc_from_cbor, encode_signed_vc_to_cbor,
-            sign_cbor_vc, sign_cbor_vc_with_algorithm, verify_cbor_vc, verify_cbor_vc_auto,
-            verify_cbor_vc_with_algorithm, Cbor,
-        },
-        protobuf::{
-            decode_signed_vc_from_protobuf, decode_unsigned_vc_from_protobuf,
-            encode_signed_vc_to_protobuf, encode_unsigned_vc_to_protobuf, sign_protobuf_vc,
-            sign_protobuf_vc_with_algorithm, verify_protobuf_vc, verify_protobuf_vc_auto,
-            verify_protobuf_vc_with_algorithm, Protobuf,
-        },
-        CredentialCodec,
-    },
+    bindings::{cbor::Cbor, protobuf::Protobuf, CredentialCodec},
     generate_keypair_bytes, Algorithm, SigningKey, UnsignedVerifiableCredential, VcError,
     VerifiableCredential, VerifyingKey,
 };
@@ -49,7 +35,7 @@ fn sample_signed_vc(private_key: &SigningKey) -> VerifiableCredential {
 }
 
 fn unsigned_vc_to_protobuf_bytes(vc: &UnsignedVerifiableCredential) -> Vec<u8> {
-    encode_unsigned_vc_to_protobuf(vc).expect("Failed to encode unsigned VC to protobuf")
+    Protobuf::encode_unsigned(vc).expect("Failed to encode unsigned VC to protobuf")
 }
 
 /// Build an unsigned VC whose `credentialSubject` carries `value`, the arbitrary-JSON
@@ -67,7 +53,7 @@ fn vc_with_subject_value(value: serde_json::Value) -> UnsignedVerifiableCredenti
 /// Round-trip a `credentialSubject.value` through Protobuf and return what comes back.
 fn protobuf_roundtrip_subject_value(value: serde_json::Value) -> serde_json::Value {
     let vc = vc_with_subject_value(value);
-    let bytes = encode_unsigned_vc_to_protobuf(&vc).expect("protobuf encode failed");
+    let bytes = Protobuf::encode_unsigned(&vc).expect("protobuf encode failed");
     let decoded = Protobuf::decode_unsigned(&bytes).expect("protobuf decode failed");
     serde_json::to_value(&decoded).expect("re-serialize decoded VC")["credentialSubject"]["value"]
         .clone()
@@ -76,8 +62,8 @@ fn protobuf_roundtrip_subject_value(value: serde_json::Value) -> serde_json::Val
 /// Round-trip a `credentialSubject.value` through CBOR and return what comes back.
 fn cbor_roundtrip_subject_value(value: serde_json::Value) -> serde_json::Value {
     let vc = vc_with_subject_value(value);
-    let bytes = to_vec(&vc).expect("CBOR encode failed");
-    let decoded = decode_unsigned_vc_from_cbor(&bytes).expect("CBOR decode failed");
+    let bytes = Cbor::encode_unsigned(&vc).expect("CBOR encode failed");
+    let decoded = Cbor::decode_unsigned(&bytes).expect("CBOR decode failed");
     serde_json::to_value(&decoded).expect("re-serialize decoded VC")["credentialSubject"]["value"]
         .clone()
 }
@@ -87,10 +73,13 @@ fn cbor_sign_and_verify_roundtrip() {
     let private_key = load_private_key();
     let public_key = load_public_key();
 
-    let unsigned_bytes = to_vec(&sample_unsigned_vc()).expect("Failed to encode unsigned VC");
-    let signed_bytes = sign_cbor_vc(&unsigned_bytes, &private_key).expect("CBOR signing failed");
+    let unsigned_bytes =
+        Cbor::encode_unsigned(&sample_unsigned_vc()).expect("Failed to encode unsigned VC");
+    let signed_bytes = Cbor::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key.to_bytes())
+        .expect("CBOR signing failed");
 
-    verify_cbor_vc(&signed_bytes, &public_key).expect("CBOR verification failed");
+    Cbor::verify(&signed_bytes, Algorithm::Ed25519, &public_key.to_bytes())
+        .expect("CBOR verification failed");
 }
 
 #[test]
@@ -99,19 +88,20 @@ fn cbor_encode_decode_signed_roundtrip() {
     let public_key = load_public_key();
 
     let signed_vc = sample_signed_vc(&private_key);
-    let cbor_bytes = encode_signed_vc_to_cbor(&signed_vc).expect("Failed to encode signed VC");
-    let decoded_vc = decode_signed_vc_from_cbor(&cbor_bytes).expect("Failed to decode signed VC");
+    let cbor_bytes = Cbor::encode_signed(&signed_vc).expect("Failed to encode signed VC");
+    let decoded_vc = Cbor::decode_signed(&cbor_bytes).expect("Failed to decode signed VC");
 
     assert_eq!(signed_vc, decoded_vc);
-    verify_cbor_vc(&cbor_bytes, &public_key).expect("CBOR verification failed");
+    Cbor::verify(&cbor_bytes, Algorithm::Ed25519, &public_key.to_bytes())
+        .expect("CBOR verification failed");
 }
 
 #[test]
 fn cbor_decode_rejects_invalid_bytes() {
     let invalid = [0xff];
 
-    assert!(decode_unsigned_vc_from_cbor(&invalid).is_err());
-    assert!(decode_signed_vc_from_cbor(&invalid).is_err());
+    assert!(Cbor::decode_unsigned(&invalid).is_err());
+    assert!(Cbor::decode_signed(&invalid).is_err());
 }
 
 #[test]
@@ -119,15 +109,16 @@ fn cbor_verify_rejects_tampered_payload() {
     let private_key = load_private_key();
     let public_key = load_public_key();
 
-    let unsigned_bytes = to_vec(&sample_unsigned_vc()).expect("Failed to encode unsigned VC");
-    let mut signed_bytes =
-        sign_cbor_vc(&unsigned_bytes, &private_key).expect("CBOR signing failed");
+    let unsigned_bytes =
+        Cbor::encode_unsigned(&sample_unsigned_vc()).expect("Failed to encode unsigned VC");
+    let mut signed_bytes = Cbor::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key.to_bytes())
+        .expect("CBOR signing failed");
 
     assert!(!signed_bytes.is_empty());
     let idx = signed_bytes.len() / 2;
     signed_bytes[idx] ^= 0x01;
 
-    assert!(verify_cbor_vc(&signed_bytes, &public_key).is_err());
+    assert!(Cbor::verify(&signed_bytes, Algorithm::Ed25519, &public_key.to_bytes()).is_err());
 }
 
 #[test]
@@ -136,10 +127,11 @@ fn protobuf_sign_and_verify_roundtrip() {
     let public_key = load_public_key();
 
     let unsigned_bytes = unsigned_vc_to_protobuf_bytes(&sample_unsigned_vc());
-    let signed_bytes =
-        sign_protobuf_vc(&unsigned_bytes, &private_key).expect("Protobuf signing failed");
+    let signed_bytes = Protobuf::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key.to_bytes())
+        .expect("Protobuf signing failed");
 
-    verify_protobuf_vc(&signed_bytes, &public_key).expect("Protobuf verification failed");
+    Protobuf::verify(&signed_bytes, Algorithm::Ed25519, &public_key.to_bytes())
+        .expect("Protobuf verification failed");
 }
 
 #[test]
@@ -148,8 +140,7 @@ fn protobuf_encode_and_verify_roundtrip() {
     let public_key = load_public_key();
 
     let signed_vc = sample_signed_vc(&private_key);
-    let protobuf_bytes =
-        encode_signed_vc_to_protobuf(&signed_vc).expect("Failed to encode signed VC");
+    let protobuf_bytes = Protobuf::encode_signed(&signed_vc).expect("Failed to encode signed VC");
 
     // The typed schema must round-trip the credential without loss: decoding the
     // protobuf bytes back into the domain type reproduces the original exactly.
@@ -157,8 +148,8 @@ fn protobuf_encode_and_verify_roundtrip() {
         .expect("Failed to decode signed VC into domain type");
     assert_eq!(signed_vc, decoded);
 
-    assert!(decode_signed_vc_from_protobuf(&protobuf_bytes).is_ok());
-    verify_protobuf_vc(&protobuf_bytes, &public_key).expect("Protobuf verification failed");
+    Protobuf::verify(&protobuf_bytes, Algorithm::Ed25519, &public_key.to_bytes())
+        .expect("Protobuf verification failed");
 }
 
 #[test]
@@ -166,8 +157,8 @@ fn protobuf_decode_rejects_invalid_bytes() {
     // Malformed length-delimited field (truncated payload)
     let invalid = [0x0A];
 
-    assert!(decode_unsigned_vc_from_protobuf(&invalid).is_err());
-    assert!(decode_signed_vc_from_protobuf(&invalid).is_err());
+    assert!(Protobuf::decode_unsigned(&invalid).is_err());
+    assert!(Protobuf::decode_signed(&invalid).is_err());
 }
 
 /// A codec-level decode failure surfaces through the `CredentialCodec` trait as
@@ -194,13 +185,14 @@ fn protobuf_verify_rejects_tampered_payload() {
 
     let unsigned_bytes = unsigned_vc_to_protobuf_bytes(&sample_unsigned_vc());
     let mut signed_bytes =
-        sign_protobuf_vc(&unsigned_bytes, &private_key).expect("Protobuf signing failed");
+        Protobuf::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key.to_bytes())
+            .expect("Protobuf signing failed");
 
     assert!(!signed_bytes.is_empty());
     let idx = signed_bytes.len() / 2;
     signed_bytes[idx] ^= 0x01;
 
-    assert!(verify_protobuf_vc(&signed_bytes, &public_key).is_err());
+    assert!(Protobuf::verify(&signed_bytes, Algorithm::Ed25519, &public_key.to_bytes()).is_err());
 }
 
 // --- Number fidelity through each codec ---------------------------------------
@@ -318,7 +310,7 @@ fn protobuf_full_unsigned_credential_roundtrip() {
     let vc: UnsignedVerifiableCredential =
         serde_json::from_value(kitchen_sink_unsigned_json()).expect("kitchen-sink should parse");
 
-    let bytes = encode_unsigned_vc_to_protobuf(&vc).expect("encode failed");
+    let bytes = Protobuf::encode_unsigned(&vc).expect("encode failed");
     let decoded = Protobuf::decode_unsigned(&bytes).expect("decode failed");
 
     assert_eq!(vc, decoded);
@@ -335,10 +327,12 @@ fn protobuf_full_credential_signs_and_verifies() {
 
     let vc: UnsignedVerifiableCredential =
         serde_json::from_value(kitchen_sink_unsigned_json()).expect("kitchen-sink should parse");
-    let unsigned_bytes = encode_unsigned_vc_to_protobuf(&vc).expect("encode failed");
+    let unsigned_bytes = Protobuf::encode_unsigned(&vc).expect("encode failed");
 
-    let signed_bytes = sign_protobuf_vc(&unsigned_bytes, &private_key).expect("signing failed");
-    verify_protobuf_vc(&signed_bytes, &public_key).expect("verification failed");
+    let signed_bytes = Protobuf::sign(&unsigned_bytes, Algorithm::Ed25519, &private_key.to_bytes())
+        .expect("signing failed");
+    Protobuf::verify(&signed_bytes, Algorithm::Ed25519, &public_key.to_bytes())
+        .expect("verification failed");
 
     let decoded = Protobuf::decode_signed(&signed_bytes).expect("decode failed");
     assert_eq!(decoded.unsigned, vc);
@@ -372,7 +366,7 @@ fn protobuf_full_proof_fields_roundtrip() {
     }))
     .expect("fabricated signed VC should parse");
 
-    let bytes = encode_signed_vc_to_protobuf(&signed).expect("encode failed");
+    let bytes = Protobuf::encode_signed(&signed).expect("encode failed");
     let decoded = Protobuf::decode_signed(&bytes).expect("decode failed");
 
     assert_eq!(signed, decoded);
@@ -393,14 +387,11 @@ fn codecs_preserve_array_credential_subject() {
     }))
     .expect("array-subject VC should parse");
 
-    let pb = encode_unsigned_vc_to_protobuf(&vc).expect("protobuf encode");
+    let pb = Protobuf::encode_unsigned(&vc).expect("protobuf encode");
     assert_eq!(Protobuf::decode_unsigned(&pb).expect("protobuf decode"), vc);
 
-    let cbor = to_vec(&vc).expect("cbor encode");
-    assert_eq!(
-        decode_unsigned_vc_from_cbor(&cbor).expect("cbor decode"),
-        vc
-    );
+    let cbor = Cbor::encode_unsigned(&vc).expect("cbor encode");
+    assert_eq!(Cbor::decode_unsigned(&cbor).expect("cbor decode"), vc);
 }
 
 /// A `null` nested inside `credentialSubject` survives the Protobuf round-trip — the
@@ -425,7 +416,7 @@ fn protobuf_credential_status_roundtrips() {
     }))
     .expect("VC with status should parse");
 
-    let bytes = encode_unsigned_vc_to_protobuf(&vc).expect("encode failed");
+    let bytes = Protobuf::encode_unsigned(&vc).expect("encode failed");
     let decoded = Protobuf::decode_unsigned(&bytes).expect("decode failed");
 
     assert_eq!(vc, decoded);
@@ -444,20 +435,19 @@ fn signature_is_independent_of_codec() {
     let signed = unsigned.sign(&private_key).expect("signing failed");
 
     // Protobuf transport.
-    let pb = encode_signed_vc_to_protobuf(&signed).expect("protobuf encode failed");
-    verify_protobuf_vc(&pb, &public_key).expect("protobuf verification failed");
+    let pb = Protobuf::encode_signed(&signed).expect("protobuf encode failed");
+    Protobuf::verify(&pb, Algorithm::Ed25519, &public_key.to_bytes())
+        .expect("protobuf verification failed");
     assert_eq!(
         Protobuf::decode_signed(&pb).expect("protobuf decode"),
         signed
     );
 
     // CBOR transport.
-    let cbor = encode_signed_vc_to_cbor(&signed).expect("cbor encode failed");
-    verify_cbor_vc(&cbor, &public_key).expect("cbor verification failed");
-    assert_eq!(
-        decode_signed_vc_from_cbor(&cbor).expect("cbor decode"),
-        signed
-    );
+    let cbor = Cbor::encode_signed(&signed).expect("cbor encode failed");
+    Cbor::verify(&cbor, Algorithm::Ed25519, &public_key.to_bytes())
+        .expect("cbor verification failed");
+    assert_eq!(Cbor::decode_signed(&cbor).expect("cbor decode"), signed);
 }
 
 /// Regression: an object-form `issuer` carrying several extra properties must sign and
@@ -489,18 +479,20 @@ fn signing_is_stable_for_object_issuer_with_extra_properties() {
 
         let signed = unsigned.sign(&private_key).expect("signing failed");
 
-        let pb = encode_signed_vc_to_protobuf(&signed).expect("protobuf encode failed");
-        verify_protobuf_vc(&pb, &public_key).expect("protobuf verification after round-trip");
+        let pb = Protobuf::encode_signed(&signed).expect("protobuf encode failed");
+        Protobuf::verify(&pb, Algorithm::Ed25519, &public_key.to_bytes())
+            .expect("protobuf verification after round-trip");
 
-        let cbor = encode_signed_vc_to_cbor(&signed).expect("cbor encode failed");
-        verify_cbor_vc(&cbor, &public_key).expect("cbor verification after round-trip");
+        let cbor = Cbor::encode_signed(&signed).expect("cbor encode failed");
+        Cbor::verify(&cbor, Algorithm::Ed25519, &public_key.to_bytes())
+            .expect("cbor verification after round-trip");
     }
 }
 
 // --- ML-DSA over CBOR and Protobuf, and cross-format interop ------------------
 
 /// Every supported algorithm signs and verifies through both codecs (verify_auto reads
-/// the cryptosuite; verify_with_algorithm is explicit).
+/// the cryptosuite; verify with an explicit algorithm asserts it).
 #[test]
 fn all_algorithms_sign_verify_via_cbor_and_protobuf() {
     for algorithm in [
@@ -512,24 +504,24 @@ fn all_algorithms_sign_verify_via_cbor_and_protobuf() {
         let (private_key, public_key) = generate_keypair_bytes(algorithm);
 
         // CBOR
-        let unsigned_cbor = to_vec(&sample_unsigned_vc()).expect("cbor encode unsigned");
-        let signed_cbor = sign_cbor_vc_with_algorithm(&unsigned_cbor, algorithm, &private_key)
+        let unsigned_cbor =
+            Cbor::encode_unsigned(&sample_unsigned_vc()).expect("cbor encode unsigned");
+        let signed_cbor = Cbor::sign(&unsigned_cbor, algorithm, &private_key)
             .unwrap_or_else(|e| panic!("cbor sign failed for {algorithm:?}: {e}"));
-        verify_cbor_vc_auto(&signed_cbor, &public_key)
+        Cbor::verify_auto(&signed_cbor, &public_key)
             .unwrap_or_else(|e| panic!("cbor verify_auto failed for {algorithm:?}: {e}"));
-        verify_cbor_vc_with_algorithm(&signed_cbor, algorithm, &public_key)
-            .unwrap_or_else(|e| panic!("cbor verify_with_algorithm failed for {algorithm:?}: {e}"));
+        Cbor::verify(&signed_cbor, algorithm, &public_key)
+            .unwrap_or_else(|e| panic!("cbor verify failed for {algorithm:?}: {e}"));
 
         // Protobuf
-        let unsigned_pb = encode_unsigned_vc_to_protobuf(&sample_unsigned_vc())
-            .expect("protobuf encode unsigned");
-        let signed_pb = sign_protobuf_vc_with_algorithm(&unsigned_pb, algorithm, &private_key)
+        let unsigned_pb =
+            Protobuf::encode_unsigned(&sample_unsigned_vc()).expect("protobuf encode unsigned");
+        let signed_pb = Protobuf::sign(&unsigned_pb, algorithm, &private_key)
             .unwrap_or_else(|e| panic!("protobuf sign failed for {algorithm:?}: {e}"));
-        verify_protobuf_vc_auto(&signed_pb, &public_key)
+        Protobuf::verify_auto(&signed_pb, &public_key)
             .unwrap_or_else(|e| panic!("protobuf verify_auto failed for {algorithm:?}: {e}"));
-        verify_protobuf_vc_with_algorithm(&signed_pb, algorithm, &public_key).unwrap_or_else(|e| {
-            panic!("protobuf verify_with_algorithm failed for {algorithm:?}: {e}")
-        });
+        Protobuf::verify(&signed_pb, algorithm, &public_key)
+            .unwrap_or_else(|e| panic!("protobuf verify failed for {algorithm:?}: {e}"));
     }
 }
 
@@ -547,20 +539,19 @@ fn mldsa_signature_is_interoperable_across_formats() {
         .expect("core sign");
 
     // Verifies as CBOR and as Protobuf.
-    let cbor = encode_signed_vc_to_cbor(&signed).expect("cbor encode");
-    verify_cbor_vc_auto(&cbor, &public_key).expect("verify cbor");
-    let protobuf = encode_signed_vc_to_protobuf(&signed).expect("protobuf encode");
-    verify_protobuf_vc_auto(&protobuf, &public_key).expect("verify protobuf");
+    let cbor = Cbor::encode_signed(&signed).expect("cbor encode");
+    Cbor::verify_auto(&cbor, &public_key).expect("verify cbor");
+    let protobuf = Protobuf::encode_signed(&signed).expect("protobuf encode");
+    Protobuf::verify_auto(&protobuf, &public_key).expect("verify protobuf");
 
     // Signed via the CBOR pipeline, transcoded to Protobuf, still verifies.
-    let unsigned_cbor = to_vec(&sample_unsigned_vc()).expect("cbor encode unsigned");
-    let signed_cbor = sign_cbor_vc_with_algorithm(&unsigned_cbor, Algorithm::MlDsa65, &private_key)
-        .expect("cbor sign");
-    let transcoded = encode_signed_vc_to_protobuf(
-        &decode_signed_vc_from_cbor(&signed_cbor).expect("decode cbor"),
-    )
-    .expect("re-encode protobuf");
-    verify_protobuf_vc_auto(&transcoded, &public_key).expect("verify transcoded");
+    let unsigned_cbor = Cbor::encode_unsigned(&sample_unsigned_vc()).expect("cbor encode unsigned");
+    let signed_cbor =
+        Cbor::sign(&unsigned_cbor, Algorithm::MlDsa65, &private_key).expect("cbor sign");
+    let transcoded =
+        Protobuf::encode_signed(&Cbor::decode_signed(&signed_cbor).expect("decode cbor"))
+            .expect("re-encode protobuf");
+    Protobuf::verify_auto(&transcoded, &public_key).expect("verify transcoded");
 }
 
 /// The interop guarantee must hold for a number-heavy, nested `credentialSubject` — the
@@ -589,14 +580,13 @@ fn mldsa_interop_preserves_number_heavy_subject() {
         .sign_with_algorithm(Algorithm::MlDsa65, &private_key)
         .expect("core sign");
 
-    let cbor = encode_signed_vc_to_cbor(&signed).expect("cbor encode");
-    verify_cbor_vc_auto(&cbor, &public_key).expect("verify cbor");
+    let cbor = Cbor::encode_signed(&signed).expect("cbor encode");
+    Cbor::verify_auto(&cbor, &public_key).expect("verify cbor");
 
-    let protobuf = encode_signed_vc_to_protobuf(&signed).expect("protobuf encode");
-    verify_protobuf_vc_auto(&protobuf, &public_key).expect("verify protobuf");
+    let protobuf = Protobuf::encode_signed(&signed).expect("protobuf encode");
+    Protobuf::verify_auto(&protobuf, &public_key).expect("verify protobuf");
 
-    let transcoded =
-        encode_signed_vc_to_protobuf(&decode_signed_vc_from_cbor(&cbor).expect("decode cbor"))
-            .expect("re-encode protobuf");
-    verify_protobuf_vc_auto(&transcoded, &public_key).expect("verify transcoded");
+    let transcoded = Protobuf::encode_signed(&Cbor::decode_signed(&cbor).expect("decode cbor"))
+        .expect("re-encode protobuf");
+    Protobuf::verify_auto(&transcoded, &public_key).expect("verify transcoded");
 }

--- a/tests/bindings.rs
+++ b/tests/bindings.rs
@@ -562,3 +562,41 @@ fn mldsa_signature_is_interoperable_across_formats() {
     .expect("re-encode protobuf");
     verify_protobuf_vc_auto(&transcoded, &public_key).expect("verify transcoded");
 }
+
+/// The interop guarantee must hold for a number-heavy, nested `credentialSubject` — the
+/// case where any canonicalization mismatch across formats would surface. Sign such a
+/// credential with ML-DSA via the JSON core, then verify it as CBOR and as Protobuf, and
+/// after a CBOR->Protobuf transcode.
+#[test]
+fn mldsa_interop_preserves_number_heavy_subject() {
+    let (private_key, public_key) = generate_keypair_bytes(Algorithm::MlDsa65);
+
+    let unsigned: UnsignedVerifiableCredential = serde_json::from_value(serde_json::json!({
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
+        "type": ["VerifiableCredential"],
+        "issuer": "https://example.com/issuer",
+        "credentialSubject": {
+            "id": "did:example:subject",
+            "count": 42,
+            "big": 9007199254740993i64,
+            "ratio": 0.25,
+            "nested": { "flag": true, "missing": serde_json::Value::Null, "list": [1, "two", 3.5] }
+        }
+    }))
+    .expect("number-heavy VC should deserialize");
+
+    let signed = unsigned
+        .sign_with_algorithm(Algorithm::MlDsa65, &private_key)
+        .expect("core sign");
+
+    let cbor = encode_signed_vc_to_cbor(&signed).expect("cbor encode");
+    verify_cbor_vc_auto(&cbor, &public_key).expect("verify cbor");
+
+    let protobuf = encode_signed_vc_to_protobuf(&signed).expect("protobuf encode");
+    verify_protobuf_vc_auto(&protobuf, &public_key).expect("verify protobuf");
+
+    let transcoded =
+        encode_signed_vc_to_protobuf(&decode_signed_vc_from_cbor(&cbor).expect("decode cbor"))
+            .expect("re-encode protobuf");
+    verify_protobuf_vc_auto(&transcoded, &public_key).expect("verify transcoded");
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -3,9 +3,10 @@ mod tests {
     use chrono::{DateTime, Duration, Utc};
     use url::Url;
     use verifiable_credential_toolkit::{
-        generate_keypair, generate_keypair_bytes, Algorithm, Holder, HolderObject, Issuer,
-        IssuerObject, Proof, SchemaSource, SigningKey, UnsignedVerifiableCredential, VcError,
-        VerifiableCredential, VerifiablePresentation, VerifyingKey,
+        generate_keypair, generate_keypair_bytes, generate_ml_dsa_keypair, Algorithm, Holder,
+        HolderObject, Issuer, IssuerObject, MlDsaSigningKey, MlDsaVerifyingKey, Proof,
+        SchemaSource, SigningKey, UnsignedVerifiableCredential, VcError, VerifiableCredential,
+        VerifiablePresentation, VerifyingKey,
     };
 
     /// Load the test signing key from disk.
@@ -869,6 +870,250 @@ mod tests {
         assert!(matches!(
             signed.verify_auto(&public_key),
             Err(VcError::UnsupportedCryptosuite(suite)) if suite == "bbs-2023"
+        ));
+    }
+
+    /// The Ed25519-typed `verify` must refuse a credential whose proof names a non-Ed25519
+    /// cryptosuite (e.g. ML-DSA), rather than silently trying to read 32-byte Ed25519 keys
+    /// out of an ML-DSA proof. This is the distinguishing branch of `verify` vs
+    /// `verify_with_algorithm` (which trusts the caller's algorithm).
+    #[test]
+    fn ed25519_verify_rejects_mldsa_cryptosuite() {
+        let (private_key, _) = generate_keypair_bytes(Algorithm::MlDsa65);
+        let signed = sample_unsigned()
+            .sign_with_algorithm(Algorithm::MlDsa65, &private_key)
+            .expect("sign");
+
+        // `verify` is Ed25519-only; the ML-DSA cryptosuite must be rejected up front.
+        assert!(matches!(
+            signed.verify(&verifying_key()),
+            Err(VcError::UnsupportedCryptosuite(suite)) if suite == "mldsa65-jcs-2025"
+        ));
+    }
+
+    /// `generate_keypair_bytes` must emit keys of exactly the FIPS 204 / Ed25519 lengths the
+    /// bilateral wire contract pins (see ML_DSA_NOTES.md). A drift here silently breaks
+    /// interop with partners, so lock the sizes in a test.
+    #[test]
+    fn keypair_byte_lengths_match_wire_contract() {
+        for (algorithm, private_len, public_len) in [
+            (Algorithm::Ed25519, 32, 32),
+            (Algorithm::MlDsa44, 2560, 1312),
+            (Algorithm::MlDsa65, 4032, 1952),
+            (Algorithm::MlDsa87, 4896, 2592),
+        ] {
+            let (private_key, public_key) = generate_keypair_bytes(algorithm);
+            assert_eq!(
+                private_key.len(),
+                private_len,
+                "{algorithm:?} private key length"
+            );
+            assert_eq!(
+                public_key.len(),
+                public_len,
+                "{algorithm:?} public key length"
+            );
+        }
+    }
+
+    /// ML-DSA signing is hedged (FIPS 204 randomized variant), so signing the same payload
+    /// twice yields different `proofValue`s — and both must still verify. Guards against a
+    /// regression to deterministic signing.
+    #[test]
+    fn mldsa_signing_is_hedged_and_nondeterministic() {
+        let (private_key, public_key) = generate_keypair_bytes(Algorithm::MlDsa65);
+
+        let first = sample_unsigned()
+            .sign_with_algorithm(Algorithm::MlDsa65, &private_key)
+            .expect("first sign");
+        let second = sample_unsigned()
+            .sign_with_algorithm(Algorithm::MlDsa65, &private_key)
+            .expect("second sign");
+
+        assert_ne!(
+            first.proof.proof_value(),
+            second.proof.proof_value(),
+            "hedged ML-DSA signatures over the same payload must differ"
+        );
+        first.verify_auto(&public_key).expect("first verifies");
+        second.verify_auto(&public_key).expect("second verifies");
+    }
+
+    /// A wrong-length ML-DSA signing key must surface as a typed `KeyDecode` error, not a
+    /// panic — the FIPS 204 expanded-key loader can panic on malformed bytes, and signing
+    /// guards against that since keys are caller-supplied (see ML_DSA_NOTES.md §3).
+    #[test]
+    fn mldsa_sign_rejects_wrong_length_key_without_panicking() {
+        for bad_key in [vec![0u8; 16], vec![0u8; 4031], vec![7u8; 5000]] {
+            assert!(matches!(
+                sample_unsigned().sign_with_algorithm(Algorithm::MlDsa65, &bad_key),
+                Err(VcError::KeyDecode(_))
+            ));
+        }
+    }
+
+    /// A wrong-length ML-DSA public key is rejected at verification with `InvalidPublicKey`,
+    /// distinct from a well-formed-but-wrong key (which fails as `SignatureVerificationFailed`).
+    #[test]
+    fn mldsa_verify_rejects_wrong_length_public_key() {
+        let (private_key, _) = generate_keypair_bytes(Algorithm::MlDsa65);
+        let signed = sample_unsigned()
+            .sign_with_algorithm(Algorithm::MlDsa65, &private_key)
+            .expect("sign");
+
+        assert!(matches!(
+            signed.verify_with_algorithm(Algorithm::MlDsa65, &[0u8; 100]),
+            Err(VcError::InvalidPublicKey(_))
+        ));
+    }
+
+    /// A well-formed ML-DSA signature verified against a different (valid) key of the same
+    /// parameter set fails as `SignatureVerificationFailed` — the ML-DSA analogue of
+    /// [verify_rejects_wrong_public_key].
+    #[test]
+    fn mldsa_verify_rejects_wrong_key_same_param_set() {
+        let (private_key, _) = generate_keypair_bytes(Algorithm::MlDsa65);
+        let (_, other_public_key) = generate_keypair_bytes(Algorithm::MlDsa65);
+
+        let signed = sample_unsigned()
+            .sign_with_algorithm(Algorithm::MlDsa65, &private_key)
+            .expect("sign");
+
+        assert!(matches!(
+            signed.verify_auto(&other_public_key),
+            Err(VcError::SignatureVerificationFailed)
+        ));
+    }
+
+    /// Round-trips every `Algorithm` through its `cryptosuite` string and back, pinning the
+    /// provisional ML-DSA identifiers and ensuring the two mappings stay mutually inverse.
+    #[test]
+    fn algorithm_cryptosuite_round_trips() {
+        for algorithm in [
+            Algorithm::Ed25519,
+            Algorithm::MlDsa44,
+            Algorithm::MlDsa65,
+            Algorithm::MlDsa87,
+        ] {
+            assert_eq!(
+                Algorithm::from_cryptosuite(algorithm.cryptosuite()),
+                Some(algorithm)
+            );
+        }
+        assert_eq!(Algorithm::from_cryptosuite("not-a-real-suite"), None);
+    }
+
+    // --- Typed ML-DSA keys ----------------------------------------------------
+
+    /// The typed-key path: `generate_ml_dsa_keypair` → `sign_ml_dsa` → `verify_ml_dsa` for
+    /// every ML-DSA parameter set. The algorithm rides along with the key, so no separate
+    /// `Algorithm` argument is threaded through.
+    #[test]
+    fn ml_dsa_typed_keys_sign_and_verify() {
+        for algorithm in [Algorithm::MlDsa44, Algorithm::MlDsa65, Algorithm::MlDsa87] {
+            let keypair = generate_ml_dsa_keypair(algorithm).expect("generate typed ML-DSA keys");
+            assert_eq!(keypair.signing_key.algorithm(), algorithm);
+
+            let signed = sample_unsigned()
+                .sign_ml_dsa(&keypair.signing_key)
+                .unwrap_or_else(|e| panic!("sign_ml_dsa failed for {algorithm:?}: {e}"));
+            signed
+                .verify_ml_dsa(&keypair.verifying_key)
+                .unwrap_or_else(|e| panic!("verify_ml_dsa failed for {algorithm:?}: {e}"));
+        }
+    }
+
+    /// `generate_ml_dsa_keypair` and the typed-key constructors reject Ed25519 — they are an
+    /// ML-DSA-only convenience.
+    #[test]
+    fn typed_ml_dsa_keys_reject_ed25519() {
+        assert!(matches!(
+            generate_ml_dsa_keypair(Algorithm::Ed25519),
+            Err(VcError::KeyDecode(_))
+        ));
+        assert!(matches!(
+            MlDsaSigningKey::new(Algorithm::Ed25519, &[0u8; 32]),
+            Err(VcError::KeyDecode(_))
+        ));
+        assert!(matches!(
+            MlDsaVerifyingKey::new(Algorithm::Ed25519, &[0u8; 32]),
+            Err(VcError::KeyDecode(_))
+        ));
+    }
+
+    /// The typed-key constructors length-check against the parameter set, so a wrong-length
+    /// buffer is rejected up front rather than at sign/verify time.
+    #[test]
+    fn typed_ml_dsa_keys_reject_wrong_length() {
+        // ML-DSA-65 signing key is 4032 bytes, verifying key 1952.
+        assert!(matches!(
+            MlDsaSigningKey::new(Algorithm::MlDsa65, &[0u8; 4031]),
+            Err(VcError::KeyDecode(_))
+        ));
+        assert!(matches!(
+            MlDsaVerifyingKey::new(Algorithm::MlDsa65, &[0u8; 1953]),
+            Err(VcError::KeyDecode(_))
+        ));
+        // A verifying-key-sized buffer is still wrong for a signing key.
+        assert!(matches!(
+            MlDsaSigningKey::new(Algorithm::MlDsa65, &[0u8; 1952]),
+            Err(VcError::KeyDecode(_))
+        ));
+    }
+
+    /// `verify_ml_dsa` pins the proof's cryptosuite to the key's parameter set: a credential
+    /// signed with ML-DSA-44 must not verify under an ML-DSA-87 key (even though both are
+    /// valid keys), surfacing as `UnsupportedCryptosuite`.
+    #[test]
+    fn verify_ml_dsa_rejects_mismatched_param_set() {
+        let kp_44 = generate_ml_dsa_keypair(Algorithm::MlDsa44).expect("44 keys");
+        let kp_87 = generate_ml_dsa_keypair(Algorithm::MlDsa87).expect("87 keys");
+
+        let signed = sample_unsigned()
+            .sign_ml_dsa(&kp_44.signing_key)
+            .expect("sign with ML-DSA-44");
+
+        assert!(matches!(
+            signed.verify_ml_dsa(&kp_87.verifying_key),
+            Err(VcError::UnsupportedCryptosuite(suite)) if suite == "mldsa44-jcs-2025"
+        ));
+    }
+
+    /// The signing key's `Debug` must not leak the secret bytes.
+    #[test]
+    fn ml_dsa_signing_key_debug_is_redacted() {
+        let keypair = generate_ml_dsa_keypair(Algorithm::MlDsa65).expect("keys");
+        let debug = format!("{:?}", keypair.signing_key);
+        assert!(debug.contains("REDACTED"), "got: {debug}");
+        // A run of the raw key bytes must not appear in the Debug output.
+        let raw = format!("{:?}", keypair.signing_key.as_bytes());
+        assert!(!debug.contains(&raw));
+    }
+
+    /// A `DataIntegrityProof` with no `cryptosuite` is rejected rather than assumed to be
+    /// Ed25519 — by both the Ed25519-typed `verify` and `verify_auto`.
+    #[test]
+    fn verify_rejects_missing_cryptosuite() {
+        let vc: VerifiableCredential = serde_json::from_value(serde_json::json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential"],
+            "issuer": "https://example.com/",
+            "credentialSubject": { "id": "did:example:subject" },
+            "proof": {
+                "type": "DataIntegrityProof",
+                "proofPurpose": "assertionMethod",
+                "proofValue": "z111" // never reached; cryptosuite check fails first
+            }
+        }))
+        .expect("VC without cryptosuite should still deserialize");
+
+        assert!(matches!(
+            vc.verify(&verifying_key()),
+            Err(VcError::MissingCryptosuite)
+        ));
+        assert!(matches!(
+            vc.verify_auto(&[0u8; 32]),
+            Err(VcError::MissingCryptosuite)
         ));
     }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -3,9 +3,9 @@ mod tests {
     use chrono::{DateTime, Duration, Utc};
     use url::Url;
     use verifiable_credential_toolkit::{
-        generate_keypair, Holder, HolderObject, Issuer, IssuerObject, SchemaSource, SigningKey,
-        UnsignedVerifiableCredential, VcError, VerifiableCredential, VerifiablePresentation,
-        VerifyingKey,
+        generate_keypair, generate_keypair_bytes, Algorithm, Holder, HolderObject, Issuer,
+        IssuerObject, Proof, SchemaSource, SigningKey, UnsignedVerifiableCredential, VcError,
+        VerifiableCredential, VerifiablePresentation, VerifyingKey,
     };
 
     /// Load the test signing key from disk.
@@ -361,7 +361,7 @@ mod tests {
 
         assert!(matches!(
             verify_result,
-            Err(VcError::SignatureVerificationFailed(_))
+            Err(VcError::SignatureVerificationFailed)
         ));
     }
 
@@ -600,7 +600,7 @@ mod tests {
         let other = generate_keypair();
         assert!(matches!(
             signed_vc.verify(&other.verifying_key),
-            Err(VcError::SignatureVerificationFailed(_))
+            Err(VcError::SignatureVerificationFailed)
         ));
     }
 
@@ -745,5 +745,108 @@ mod tests {
         let back: VerifiableCredential = serde_json::from_str(&json).unwrap();
 
         assert_eq!(signed, back);
+    }
+
+    // --- Multi-algorithm signing (ML-DSA) -------------------------------------
+
+    fn sample_unsigned() -> UnsignedVerifiableCredential {
+        serde_json::from_value(serde_json::json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential"],
+            "issuer": "https://example.com/issuer",
+            "credentialSubject": { "id": "did:example:subject", "n": 42 }
+        }))
+        .expect("sample VC should deserialize")
+    }
+
+    /// Generated keypair → sign_with_algorithm → verify_with_algorithm and verify_auto,
+    /// for every supported algorithm including the three ML-DSA parameter sets.
+    #[test]
+    fn sign_verify_roundtrip_all_algorithms() {
+        for algorithm in [
+            Algorithm::Ed25519,
+            Algorithm::MlDsa44,
+            Algorithm::MlDsa65,
+            Algorithm::MlDsa87,
+        ] {
+            let (private_key, public_key) = generate_keypair_bytes(algorithm);
+
+            let signed = sample_unsigned()
+                .sign_with_algorithm(algorithm, &private_key)
+                .unwrap_or_else(|e| panic!("sign failed for {algorithm:?}: {e}"));
+
+            // The proof records the algorithm's cryptosuite.
+            assert_eq!(
+                serde_json::to_value(&signed).unwrap()["proof"]["cryptosuite"],
+                algorithm.cryptosuite()
+            );
+
+            // Explicit-algorithm verify and cryptosuite-dispatched verify both pass.
+            signed
+                .verify_with_algorithm(algorithm, &public_key)
+                .unwrap_or_else(|e| panic!("verify_with_algorithm failed for {algorithm:?}: {e}"));
+            signed
+                .verify_auto(&public_key)
+                .unwrap_or_else(|e| panic!("verify_auto failed for {algorithm:?}: {e}"));
+        }
+    }
+
+    /// The injection path: take the canonical `signing_payload`, sign it "externally"
+    /// (here: with ML-DSA-65), then wrap the signature with `Proof::new_data_integrity` +
+    /// `set_proof_value` + `VerifiableCredential::from_parts`, and verify. This is what
+    /// unblocks signing with an algorithm computed outside the crate.
+    #[test]
+    fn external_proof_injection_roundtrip() {
+        let (private_key, public_key) = generate_keypair_bytes(Algorithm::MlDsa65);
+        let unsigned = sample_unsigned();
+
+        // Stand-in for an external signer: produce the proofValue over signing_payload.
+        let proof_value = unsigned
+            .clone()
+            .sign_with_algorithm(Algorithm::MlDsa65, &private_key)
+            .expect("sign")
+            .proof
+            .proof_value()
+            .to_string();
+
+        // Inject it into a hand-built proof and assemble the credential.
+        let proof = Proof::new_data_integrity(Algorithm::MlDsa65.cryptosuite(), String::new())
+            .set_proof_value(proof_value);
+        let injected = VerifiableCredential::from_parts(unsigned, proof);
+
+        injected
+            .verify_auto(&public_key)
+            .expect("injected ML-DSA proof should verify");
+    }
+
+    /// A signature made under one algorithm must not verify under another.
+    #[test]
+    fn cross_algorithm_verification_fails() {
+        let (sk_44, _) = generate_keypair_bytes(Algorithm::MlDsa44);
+        let (_, pk_65) = generate_keypair_bytes(Algorithm::MlDsa65);
+
+        let signed = sample_unsigned()
+            .sign_with_algorithm(Algorithm::MlDsa44, &sk_44)
+            .expect("sign");
+
+        // Wrong parameter set / key: must error, not falsely verify.
+        assert!(signed
+            .verify_with_algorithm(Algorithm::MlDsa65, &pk_65)
+            .is_err());
+    }
+
+    /// `verify_auto` rejects a proof whose cryptosuite the toolkit doesn't implement.
+    #[test]
+    fn verify_auto_rejects_unknown_cryptosuite() {
+        let (private_key, public_key) = generate_keypair_bytes(Algorithm::MlDsa65);
+        let mut signed = sample_unsigned()
+            .sign_with_algorithm(Algorithm::MlDsa65, &private_key)
+            .expect("sign");
+        signed.proof = signed.proof.set_crypto_suite("bbs-2023".to_string());
+
+        assert!(matches!(
+            signed.verify_auto(&public_key),
+            Err(VcError::UnsupportedCryptosuite(suite)) if suite == "bbs-2023"
+        ));
     }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -751,9 +751,7 @@ mod tests {
 
         // Enough distinct keys that an accidental order-match after the round-trip is
         // astronomically unlikely, so a reversion to non-canonical signing is caught.
-        let extras = [
-            "b", "a", "c", "e", "d", "z", "m", "q", "f", "t", "j", "k",
-        ];
+        let extras = ["b", "a", "c", "e", "d", "z", "m", "q", "f", "t", "j", "k"];
 
         for algorithm in [
             Algorithm::Ed25519,

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -3,23 +3,24 @@ mod tests {
     use chrono::{DateTime, Duration, Utc};
     use url::Url;
     use verifiable_credential_toolkit::{
-        generate_keypair, generate_keypair_bytes, generate_ml_dsa_keypair, Algorithm, Holder,
-        HolderObject, Issuer, IssuerObject, MlDsaSigningKey, MlDsaVerifyingKey, Proof,
-        SchemaSource, SigningKey, UnsignedVerifiableCredential, VcError, VerifiableCredential,
-        VerifiablePresentation, VerifyingKey,
+        generate_keypair, generate_keypair_bytes, Algorithm, Holder, HolderObject, Issuer,
+        IssuerObject, Proof, SchemaSource, SigningKey, UnsignedVerifiableCredential, VcError,
+        VerifiableCredential, VerifiablePresentation, VerifyingKey,
     };
 
-    /// Load the test signing key from disk.
+    /// Load the test signing key from disk (raw 32-byte Ed25519 seed).
     fn signing_key() -> SigningKey {
-        SigningKey::from_bytes(
+        SigningKey::new(
+            Algorithm::Ed25519,
             &std::fs::read("tests/test_data/keys/key.priv").expect("read private key"),
         )
         .expect("valid private key")
     }
 
-    /// Load the test verifying key from disk.
+    /// Load the test verifying key from disk (raw 32-byte Ed25519 key).
     fn verifying_key() -> VerifyingKey {
-        VerifyingKey::from_bytes(
+        VerifyingKey::new(
+            Algorithm::Ed25519,
             &std::fs::read("tests/test_data/keys/key.pub").expect("read public key"),
         )
         .expect("valid public key")
@@ -566,24 +567,24 @@ mod tests {
         assert!(matches!(verify_result, Err(VcError::SchemaMismatch)));
     }
 
-    /// Key newtypes reject anything that isn't exactly 32 bytes.
+    /// An Ed25519 key is rejected unless it is exactly 32 bytes.
     #[test]
-    fn key_from_bytes_rejects_wrong_length() {
+    fn key_new_rejects_wrong_length() {
         assert!(matches!(
-            SigningKey::from_bytes(&[0u8; 31]),
-            Err(VcError::InvalidPrivateKeyLength)
+            SigningKey::new(Algorithm::Ed25519, &[0u8; 31]),
+            Err(VcError::KeyDecode(_))
         ));
         assert!(matches!(
-            SigningKey::from_bytes(&[0u8; 33]),
-            Err(VcError::InvalidPrivateKeyLength)
+            SigningKey::new(Algorithm::Ed25519, &[0u8; 33]),
+            Err(VcError::KeyDecode(_))
         ));
         assert!(matches!(
-            VerifyingKey::from_bytes(&[0u8; 31]),
-            Err(VcError::InvalidPublicKeyLength)
+            VerifyingKey::new(Algorithm::Ed25519, &[0u8; 31]),
+            Err(VcError::KeyDecode(_))
         ));
         // Exactly 32 bytes is accepted.
-        assert!(SigningKey::from_bytes(&[7u8; 32]).is_ok());
-        assert!(VerifyingKey::from_bytes(&[7u8; 32]).is_ok());
+        assert!(SigningKey::new(Algorithm::Ed25519, &[7u8; 32]).is_ok());
+        assert!(VerifyingKey::new(Algorithm::Ed25519, &[7u8; 32]).is_ok());
     }
 
     /// A well-formed signature verified against a different (valid) public key
@@ -598,7 +599,7 @@ mod tests {
         .expect("Failed to sign VC");
 
         // A different, valid keypair: the signature is well-formed but won't match.
-        let other = generate_keypair();
+        let other = generate_keypair(Algorithm::Ed25519);
         assert!(matches!(
             signed_vc.verify(&other.verifying_key),
             Err(VcError::SignatureVerificationFailed)
@@ -731,6 +732,71 @@ mod tests {
 
         let back: UnsignedVerifiableCredential = serde_json::from_str(&json).unwrap();
         assert_eq!(vc, back);
+    }
+
+    /// Canonicalization regression guard, across every algorithm. An issuer object
+    /// carries its flattened extras in a `HashMap`, whose iteration order varies
+    /// between instances; deserialization rebuilds that map in a generally different
+    /// order than the signer used. Because `signing_payload` canonicalizes with JCS
+    /// (RFC 8785, sorted keys), the signature is taken over an order-independent form,
+    /// so a credential with *several* issuer properties still verifies after a
+    /// serialize -> deserialize round-trip. Without canonicalization the verifier would
+    /// re-serialize the keys in a different order and reject a valid credential — the
+    /// single-property `issuer_object_flatten_round_trips` above cannot catch this, and
+    /// neither would a sign/verify of the same in-memory object (its HashMap iterates
+    /// identically both times). Exercises the full sign -> round-trip -> verify loop.
+    #[test]
+    fn multi_property_issuer_verifies_after_roundtrip_all_algorithms() {
+        use std::collections::HashMap;
+
+        // Enough distinct keys that an accidental order-match after the round-trip is
+        // astronomically unlikely, so a reversion to non-canonical signing is caught.
+        let extras = [
+            "b", "a", "c", "e", "d", "z", "m", "q", "f", "t", "j", "k",
+        ];
+
+        for algorithm in [
+            Algorithm::Ed25519,
+            Algorithm::MlDsa44,
+            Algorithm::MlDsa65,
+            Algorithm::MlDsa87,
+        ] {
+            let (private_key, public_key) = generate_keypair_bytes(algorithm);
+
+            let mut extra = HashMap::new();
+            for (i, key) in extras.iter().enumerate() {
+                extra.insert((*key).to_string(), serde_json::json!(i as i64));
+            }
+
+            let unsigned = UnsignedVerifiableCredential::builder(
+                vec![Url::parse("https://www.w3.org/ns/credentials/v2").unwrap()],
+                vec!["VerifiableCredential".to_string()],
+                Issuer::Object(IssuerObject {
+                    id: Url::parse("https://issuer.example.com/").unwrap(),
+                    additional_properties: Some(extra),
+                }),
+                serde_json::json!({ "id": "did:example:subject" }),
+            )
+            .build();
+
+            let signed = unsigned
+                .sign_with_algorithm(algorithm, &private_key)
+                .unwrap_or_else(|e| panic!("sign failed for {algorithm:?}: {e}"));
+
+            // Round-trip through JSON: deserialization rebuilds the issuer's HashMap,
+            // generally in a different iteration order than the signer's.
+            let json = serde_json::to_string(&signed).unwrap();
+            let reparsed: VerifiableCredential = serde_json::from_str(&json).unwrap();
+
+            reparsed.verify_auto(&public_key).unwrap_or_else(|e| {
+                panic!("verify_auto after round-trip failed for {algorithm:?}: {e}")
+            });
+            reparsed
+                .verify_with_algorithm(algorithm, &public_key)
+                .unwrap_or_else(|e| {
+                    panic!("verify_with_algorithm after round-trip failed for {algorithm:?}: {e}")
+                });
+        }
     }
 
     /// A signed VC survives a JSON serialize -> deserialize round-trip unchanged.
@@ -1003,86 +1069,68 @@ mod tests {
         assert_eq!(Algorithm::from_cryptosuite("not-a-real-suite"), None);
     }
 
-    // --- Typed ML-DSA keys ----------------------------------------------------
+    // --- Typed keys -----------------------------------------------------------
 
-    /// The typed-key path: `generate_ml_dsa_keypair` → `sign_ml_dsa` → `verify_ml_dsa` for
-    /// every ML-DSA parameter set. The algorithm rides along with the key, so no separate
-    /// `Algorithm` argument is threaded through.
+    /// The typed-key path: `generate_keypair` → `sign` → `verify` for every ML-DSA
+    /// parameter set. The algorithm rides along with the key, so no separate `Algorithm`
+    /// argument is threaded through — the same `sign`/`verify` used for Ed25519.
     #[test]
-    fn ml_dsa_typed_keys_sign_and_verify() {
+    fn typed_keys_sign_and_verify() {
         for algorithm in [Algorithm::MlDsa44, Algorithm::MlDsa65, Algorithm::MlDsa87] {
-            let keypair = generate_ml_dsa_keypair(algorithm).expect("generate typed ML-DSA keys");
+            let keypair = generate_keypair(algorithm);
             assert_eq!(keypair.signing_key.algorithm(), algorithm);
 
             let signed = sample_unsigned()
-                .sign_ml_dsa(&keypair.signing_key)
-                .unwrap_or_else(|e| panic!("sign_ml_dsa failed for {algorithm:?}: {e}"));
+                .sign(&keypair.signing_key)
+                .unwrap_or_else(|e| panic!("sign failed for {algorithm:?}: {e}"));
             signed
-                .verify_ml_dsa(&keypair.verifying_key)
-                .unwrap_or_else(|e| panic!("verify_ml_dsa failed for {algorithm:?}: {e}"));
+                .verify(&keypair.verifying_key)
+                .unwrap_or_else(|e| panic!("verify failed for {algorithm:?}: {e}"));
         }
     }
 
-    /// `generate_ml_dsa_keypair` and the typed-key constructors reject Ed25519 — they are an
-    /// ML-DSA-only convenience.
+    /// The key constructors length-check against the algorithm, so a wrong-length buffer is
+    /// rejected up front rather than at sign/verify time.
     #[test]
-    fn typed_ml_dsa_keys_reject_ed25519() {
-        assert!(matches!(
-            generate_ml_dsa_keypair(Algorithm::Ed25519),
-            Err(VcError::KeyDecode(_))
-        ));
-        assert!(matches!(
-            MlDsaSigningKey::new(Algorithm::Ed25519, &[0u8; 32]),
-            Err(VcError::KeyDecode(_))
-        ));
-        assert!(matches!(
-            MlDsaVerifyingKey::new(Algorithm::Ed25519, &[0u8; 32]),
-            Err(VcError::KeyDecode(_))
-        ));
-    }
-
-    /// The typed-key constructors length-check against the parameter set, so a wrong-length
-    /// buffer is rejected up front rather than at sign/verify time.
-    #[test]
-    fn typed_ml_dsa_keys_reject_wrong_length() {
+    fn typed_keys_reject_wrong_length() {
         // ML-DSA-65 signing key is 4032 bytes, verifying key 1952.
         assert!(matches!(
-            MlDsaSigningKey::new(Algorithm::MlDsa65, &[0u8; 4031]),
+            SigningKey::new(Algorithm::MlDsa65, &[0u8; 4031]),
             Err(VcError::KeyDecode(_))
         ));
         assert!(matches!(
-            MlDsaVerifyingKey::new(Algorithm::MlDsa65, &[0u8; 1953]),
+            VerifyingKey::new(Algorithm::MlDsa65, &[0u8; 1953]),
             Err(VcError::KeyDecode(_))
         ));
         // A verifying-key-sized buffer is still wrong for a signing key.
         assert!(matches!(
-            MlDsaSigningKey::new(Algorithm::MlDsa65, &[0u8; 1952]),
+            SigningKey::new(Algorithm::MlDsa65, &[0u8; 1952]),
             Err(VcError::KeyDecode(_))
         ));
     }
 
-    /// `verify_ml_dsa` pins the proof's cryptosuite to the key's parameter set: a credential
-    /// signed with ML-DSA-44 must not verify under an ML-DSA-87 key (even though both are
-    /// valid keys), surfacing as `UnsupportedCryptosuite`.
+    /// `verify` pins the proof's cryptosuite to the key's parameter set: a credential signed
+    /// with ML-DSA-44 must not verify under an ML-DSA-87 key (even though both are valid
+    /// keys), surfacing as `UnsupportedCryptosuite`.
     #[test]
-    fn verify_ml_dsa_rejects_mismatched_param_set() {
-        let kp_44 = generate_ml_dsa_keypair(Algorithm::MlDsa44).expect("44 keys");
-        let kp_87 = generate_ml_dsa_keypair(Algorithm::MlDsa87).expect("87 keys");
+    fn verify_rejects_mismatched_param_set() {
+        let kp_44 = generate_keypair(Algorithm::MlDsa44);
+        let kp_87 = generate_keypair(Algorithm::MlDsa87);
 
         let signed = sample_unsigned()
-            .sign_ml_dsa(&kp_44.signing_key)
+            .sign(&kp_44.signing_key)
             .expect("sign with ML-DSA-44");
 
         assert!(matches!(
-            signed.verify_ml_dsa(&kp_87.verifying_key),
+            signed.verify(&kp_87.verifying_key),
             Err(VcError::UnsupportedCryptosuite(suite)) if suite == "mldsa44-jcs-2025"
         ));
     }
 
     /// The signing key's `Debug` must not leak the secret bytes.
     #[test]
-    fn ml_dsa_signing_key_debug_is_redacted() {
-        let keypair = generate_ml_dsa_keypair(Algorithm::MlDsa65).expect("keys");
+    fn signing_key_debug_is_redacted() {
+        let keypair = generate_keypair(Algorithm::MlDsa65);
         let debug = format!("{:?}", keypair.signing_key);
         assert!(debug.contains("REDACTED"), "got: {debug}");
         // A run of the raw key bytes must not appear in the Debug output.

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -604,10 +604,10 @@ mod tests {
         ));
     }
 
-    /// A `proofValue` that isn't valid base64 fails at the decode step — a distinct error
-    /// from a well-formed-but-wrong signature.
+    /// A `proofValue` that isn't valid multibase fails at the decode step — a distinct
+    /// error from a well-formed-but-wrong signature.
     #[test]
-    fn verify_rejects_non_base64_proof_value() {
+    fn verify_rejects_undecodable_proof_value() {
         let vc: VerifiableCredential = serde_json::from_value(serde_json::json!({
             "@context": ["https://www.w3.org/ns/credentials/v2"],
             "type": ["VerifiableCredential"],
@@ -617,7 +617,7 @@ mod tests {
                 "type": "DataIntegrityProof",
                 "cryptosuite": "eddsa-jcs-2022",
                 "proofPurpose": "assertionMethod",
-                "proofValue": "not valid base64 !!!"
+                "proofValue": "not valid multibase !!!"
             }
         }))
         .expect("VC should deserialize");
@@ -628,8 +628,9 @@ mod tests {
         ));
     }
 
-    /// A `proofValue` that decodes but isn't a 64-byte Ed25519 signature is rejected as
-    /// malformed, before any verification maths.
+    /// A `proofValue` that decodes (valid multibase) but isn't a 64-byte Ed25519
+    /// signature is rejected as malformed. `z` is the base58btc multibase prefix;
+    /// "1111111111" decodes to ten zero bytes.
     #[test]
     fn verify_rejects_malformed_signature_length() {
         let vc: VerifiableCredential = serde_json::from_value(serde_json::json!({
@@ -641,7 +642,7 @@ mod tests {
                 "type": "DataIntegrityProof",
                 "cryptosuite": "eddsa-jcs-2022",
                 "proofPurpose": "assertionMethod",
-                "proofValue": "AAAA"
+                "proofValue": "z1111111111"
             }
         }))
         .expect("VC should deserialize");
@@ -833,6 +834,27 @@ mod tests {
         assert!(signed
             .verify_with_algorithm(Algorithm::MlDsa65, &pk_65)
             .is_err());
+    }
+
+    /// A tampered credential signed with ML-DSA fails verification (the signature covers
+    /// the canonical content).
+    #[test]
+    fn mldsa_verify_rejects_tampered_payload() {
+        let (private_key, public_key) = generate_keypair_bytes(Algorithm::MlDsa65);
+        let signed = sample_unsigned()
+            .sign_with_algorithm(Algorithm::MlDsa65, &private_key)
+            .expect("sign");
+
+        // Flip a value in the subject after signing.
+        let mut json = serde_json::to_value(&signed).unwrap();
+        json["credentialSubject"]["n"] = serde_json::json!(999);
+        let tampered: VerifiableCredential =
+            serde_json::from_value(json).expect("tampered VC still deserializes");
+
+        assert!(matches!(
+            tampered.verify_auto(&public_key),
+            Err(VcError::SignatureVerificationFailed)
+        ));
     }
 
     /// `verify_auto` rejects a proof whose cryptosuite the toolkit doesn't implement.

--- a/tests/test_data/verifiable_credentials/vc.json
+++ b/tests/test_data/verifiable_credentials/vc.json
@@ -16,6 +16,6 @@
     "type": "DataIntegrityProof",
     "cryptosuite": "eddsa-jcs-2022",
     "proofPurpose": "assertionMethod",
-    "proofValue": "yKB34IktaVum9Z65J9U5FtCYCNHbo1WC3kuXm4LvAMDieuqhNoGniyuswPwKzoptfDZksIhgm7Ea3TUB0XM2DA=="
+    "proofValue": "z51eayF2RKpv7wvwrDPNW3si8ZeZ6J8FwSa6tVbF9FkutA9pZoUdGucUaF9SieuXd6FYC9nBz45yGFYriaQna5rK5"
   }
 }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -343,15 +343,25 @@ mod wasm_tests {
     // actually calls — which the Rust-API tests above don't reach.
     use verifiable_credential_toolkit::wasm;
 
+    /// Serialize to a *plain* JS object (not an ES Map), the way a JS caller passes data in.
+    /// `serde_wasm_bindgen::to_value` defaults to Maps, which the JSON.stringify-based input
+    /// cleaning in the sign/encode entry points reads as `{}` — mirror the library's own
+    /// `serialize_maps_as_objects(true)`.
+    fn to_js(value: serde_json::Value) -> wasm_bindgen::JsValue {
+        use serde::Serialize;
+        value
+            .serialize(&serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true))
+            .unwrap_or_else(|_| panic!("serialize to JsValue"))
+    }
+
     /// A sample credential as a JsValue, the way JS would pass one in.
     fn sample_credential_js() -> wasm_bindgen::JsValue {
-        serde_wasm_bindgen::to_value(&serde_json::json!({
+        to_js(serde_json::json!({
             "@context": ["https://www.w3.org/ns/credentials/v2"],
             "type": ["VerifiableCredential"],
             "issuer": "https://example.com/issuer",
             "credentialSubject": { "id": "urn:uuid:device-1", "name": "Sensor A", "count": 42 }
         }))
-        .unwrap_or_else(|_| panic!("credential to JsValue"))
     }
 
     /// generate_keypair → sign → verify over the JS ABI (Ed25519).
@@ -402,19 +412,13 @@ mod wasm_tests {
         let signed = wasm::sign(sample_credential_js(), &kp.signing_key())
             .unwrap_or_else(|_| panic!("js sign failed"));
 
-        let good = serde_wasm_bindgen::to_value(
-            &serde_json::json!({ "type": "object", "required": ["id", "name"] }),
-        )
-        .unwrap_or_else(|_| panic!("schema to JsValue"));
+        let good = to_js(serde_json::json!({ "type": "object", "required": ["id", "name"] }));
         assert!(
             wasm::verify_with_schema_check(signed.clone(), &kp.verifying_key(), good)
                 .unwrap_or_else(|_| panic!("verify_with_schema_check errored"))
         );
 
-        let bad = serde_wasm_bindgen::to_value(
-            &serde_json::json!({ "type": "object", "required": ["missing_field"] }),
-        )
-        .unwrap_or_else(|_| panic!("schema to JsValue"));
+        let bad = to_js(serde_json::json!({ "type": "object", "required": ["missing_field"] }));
         assert!(
             !wasm::verify_with_schema_check(signed, &kp.verifying_key(), bad)
                 .unwrap_or_else(|_| panic!("verify_with_schema_check errored")),

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -52,8 +52,11 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
-            .expect("Invalid private key");
+        let private_key = SigningKey::new(
+            Algorithm::Ed25519,
+            include_bytes!("test_data/keys/key.priv"),
+        )
+        .expect("Invalid private key");
 
         let signed_vc = vc.sign(&private_key).unwrap();
 
@@ -73,8 +76,11 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
-            .expect("Invalid private key");
+        let private_key = SigningKey::new(
+            Algorithm::Ed25519,
+            include_bytes!("test_data/keys/key.priv"),
+        )
+        .expect("Invalid private key");
 
         let signed_vc = vc.sign(&private_key).expect("Failed to sign VC");
 
@@ -90,8 +96,11 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
-            .expect("Invalid private key");
+        let private_key = SigningKey::new(
+            Algorithm::Ed25519,
+            include_bytes!("test_data/keys/key.priv"),
+        )
+        .expect("Invalid private key");
 
         let schema_str = include_str!("test_data/schemas/schema.json");
         let schema: serde_json::Value =
@@ -112,8 +121,11 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
-            .expect("Invalid private key");
+        let private_key = SigningKey::new(
+            Algorithm::Ed25519,
+            include_bytes!("test_data/keys/key.priv"),
+        )
+        .expect("Invalid private key");
 
         let schema_str = include_str!("test_data/schemas/schema_fail.json");
         let schema: serde_json::Value =
@@ -128,8 +140,11 @@ mod wasm_tests {
 
     #[wasm_bindgen_test]
     fn signed_to_unsigned() {
-        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
-            .expect("Invalid private key");
+        let private_key = SigningKey::new(
+            Algorithm::Ed25519,
+            include_bytes!("test_data/keys/key.priv"),
+        )
+        .expect("Invalid private key");
 
         let vc: VerifiableCredential = serde_json::from_str::<UnsignedVerifiableCredential>(
             include_str!("test_data/verifiable_credentials/unsigned.json"),
@@ -160,8 +175,11 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
-            .expect("Invalid private key");
+        let private_key = SigningKey::new(
+            Algorithm::Ed25519,
+            include_bytes!("test_data/keys/key.priv"),
+        )
+        .expect("Invalid private key");
 
         let mut signed_vc = vc.sign(&private_key).unwrap();
 
@@ -191,8 +209,11 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
-            .expect("Invalid private key");
+        let private_key = SigningKey::new(
+            Algorithm::Ed25519,
+            include_bytes!("test_data/keys/key.priv"),
+        )
+        .expect("Invalid private key");
 
         let mut signed_vc = vc.sign(&private_key).unwrap();
 
@@ -235,8 +256,11 @@ mod wasm_tests {
 
     #[wasm_bindgen_test]
     fn verify_signed_verifiable_credential() {
-        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
-            .expect("Invalid private key");
+        let private_key = SigningKey::new(
+            Algorithm::Ed25519,
+            include_bytes!("test_data/keys/key.priv"),
+        )
+        .expect("Invalid private key");
 
         let vc: VerifiableCredential = serde_json::from_str::<UnsignedVerifiableCredential>(
             include_str!("test_data/verifiable_credentials/unsigned.json"),
@@ -245,8 +269,9 @@ mod wasm_tests {
         .sign(&private_key)
         .expect("Failed to sign VC");
 
-        let public_key = VerifyingKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.pub"))
-            .expect("Invalid public key");
+        let public_key =
+            VerifyingKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.pub"))
+                .expect("Invalid public key");
         let verify_result = vc.verify(&public_key);
 
         match &verify_result {
@@ -258,8 +283,11 @@ mod wasm_tests {
 
     #[wasm_bindgen_test]
     fn verify_denies_modified_verifiable_credential() {
-        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
-            .expect("Invalid private key");
+        let private_key = SigningKey::new(
+            Algorithm::Ed25519,
+            include_bytes!("test_data/keys/key.priv"),
+        )
+        .expect("Invalid private key");
 
         let vc: VerifiableCredential = serde_json::from_str::<UnsignedVerifiableCredential>(
             include_str!("test_data/verifiable_credentials/unsigned.json"),
@@ -275,8 +303,9 @@ mod wasm_tests {
         let edited_vc: VerifiableCredential =
             serde_json::from_str(&vc_serialized).expect("Failed to deserialize JSON");
 
-        let public_key = VerifyingKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.pub"))
-            .expect("Invalid public key");
+        let public_key =
+            VerifyingKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.pub"))
+                .expect("Invalid public key");
 
         let verify_result = edited_vc.verify(&public_key);
 
@@ -307,5 +336,141 @@ mod wasm_tests {
                 .verify_auto(&public_key)
                 .expect("ML-DSA verification should work on wasm");
         }
+    }
+
+    // --- JavaScript / wasm-bindgen ABI ----------------------------------------
+    // Exercise the #[wasm_bindgen] entry points in src/wasm.rs — the functions JS
+    // actually calls — which the Rust-API tests above don't reach.
+    use verifiable_credential_toolkit::wasm;
+
+    /// A sample credential as a JsValue, the way JS would pass one in.
+    fn sample_credential_js() -> wasm_bindgen::JsValue {
+        serde_wasm_bindgen::to_value(&serde_json::json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential"],
+            "issuer": "https://example.com/issuer",
+            "credentialSubject": { "id": "urn:uuid:device-1", "name": "Sensor A", "count": 42 }
+        }))
+        .unwrap_or_else(|_| panic!("credential to JsValue"))
+    }
+
+    /// generate_keypair → sign → verify over the JS ABI (Ed25519).
+    #[wasm_bindgen_test]
+    fn js_sign_and_verify_roundtrip() {
+        let kp = wasm::generate_keypair();
+        let signed = wasm::sign(sample_credential_js(), &kp.signing_key())
+            .unwrap_or_else(|_| panic!("js sign failed"));
+        let ok = wasm::verify(signed, &kp.verifying_key())
+            .unwrap_or_else(|_| panic!("js verify errored"));
+        assert!(ok, "freshly signed credential should verify");
+    }
+
+    /// The JS `verify` returns `false` (not an error) for a valid-but-wrong key.
+    #[wasm_bindgen_test]
+    fn js_verify_returns_false_on_wrong_key() {
+        let kp = wasm::generate_keypair();
+        let other = wasm::generate_keypair();
+        let signed = wasm::sign(sample_credential_js(), &kp.signing_key())
+            .unwrap_or_else(|_| panic!("js sign failed"));
+        let ok = wasm::verify(signed, &other.verifying_key())
+            .unwrap_or_else(|_| panic!("js verify errored"));
+        assert!(!ok, "wrong key must not verify");
+    }
+
+    /// Multi-algorithm JS path: generate_keypair_for → sign_with_algorithm →
+    /// verify_auto / verify_with_algorithm (ML-DSA-65).
+    #[wasm_bindgen_test]
+    fn js_multi_algorithm_sign_verify() {
+        let kp = wasm::generate_keypair_for("ML-DSA-65")
+            .unwrap_or_else(|_| panic!("generate ML-DSA-65 keypair"));
+        let signed =
+            wasm::sign_with_algorithm(sample_credential_js(), "ML-DSA-65", &kp.signing_key())
+                .unwrap_or_else(|_| panic!("js sign_with_algorithm failed"));
+        assert!(wasm::verify_auto(signed.clone(), &kp.verifying_key())
+            .unwrap_or_else(|_| panic!("verify_auto errored")));
+        assert!(
+            wasm::verify_with_algorithm(signed, "ML-DSA-65", &kp.verifying_key())
+                .unwrap_or_else(|_| panic!("verify_with_algorithm errored"))
+        );
+    }
+
+    /// JS verify_with_schema_check passes a matching schema and rejects a non-matching one
+    /// (returning false rather than erroring).
+    #[wasm_bindgen_test]
+    fn js_verify_with_schema_check() {
+        let kp = wasm::generate_keypair();
+        let signed = wasm::sign(sample_credential_js(), &kp.signing_key())
+            .unwrap_or_else(|_| panic!("js sign failed"));
+
+        let good = serde_wasm_bindgen::to_value(
+            &serde_json::json!({ "type": "object", "required": ["id", "name"] }),
+        )
+        .unwrap_or_else(|_| panic!("schema to JsValue"));
+        assert!(
+            wasm::verify_with_schema_check(signed.clone(), &kp.verifying_key(), good)
+                .unwrap_or_else(|_| panic!("verify_with_schema_check errored"))
+        );
+
+        let bad = serde_wasm_bindgen::to_value(
+            &serde_json::json!({ "type": "object", "required": ["missing_field"] }),
+        )
+        .unwrap_or_else(|_| panic!("schema to JsValue"));
+        assert!(
+            !wasm::verify_with_schema_check(signed, &kp.verifying_key(), bad)
+                .unwrap_or_else(|_| panic!("verify_with_schema_check errored")),
+            "a credential that fails the schema must not verify"
+        );
+    }
+
+    /// JS CBOR path: encode → sign → verify, plus decode back to a JS object.
+    #[wasm_bindgen_test]
+    fn js_cbor_sign_verify_and_decode() {
+        let kp = wasm::generate_keypair();
+        let unsigned = wasm::encode_unsigned_vc_to_cbor(sample_credential_js())
+            .unwrap_or_else(|_| panic!("encode cbor"));
+        let signed = wasm::sign_cbor_vc(&unsigned, &kp.signing_key())
+            .unwrap_or_else(|_| panic!("sign cbor"));
+        assert!(wasm::verify_cbor_vc(&signed, &kp.verifying_key())
+            .unwrap_or_else(|_| panic!("verify cbor errored")));
+        let _decoded =
+            wasm::decode_signed_vc_from_cbor(&signed).unwrap_or_else(|_| panic!("decode cbor"));
+    }
+
+    /// JS Protobuf path: encode → sign → verify.
+    #[wasm_bindgen_test]
+    fn js_protobuf_sign_verify() {
+        let kp = wasm::generate_keypair();
+        let unsigned = wasm::encode_unsigned_vc_to_protobuf(sample_credential_js())
+            .unwrap_or_else(|_| panic!("encode protobuf"));
+        let signed = wasm::sign_protobuf_vc(&unsigned, &kp.signing_key())
+            .unwrap_or_else(|_| panic!("sign protobuf"));
+        assert!(wasm::verify_protobuf_vc(&signed, &kp.verifying_key())
+            .unwrap_or_else(|_| panic!("verify protobuf errored")));
+    }
+
+    /// The multi-algorithm codec JS functions: sign_*_with_algorithm + verify_*_auto over
+    /// both CBOR and Protobuf, with ML-DSA.
+    #[wasm_bindgen_test]
+    fn js_codec_multi_algorithm() {
+        let kp = wasm::generate_keypair_for("ML-DSA-44")
+            .unwrap_or_else(|_| panic!("generate ML-DSA-44 keypair"));
+
+        let unsigned_cbor = wasm::encode_unsigned_vc_to_cbor(sample_credential_js())
+            .unwrap_or_else(|_| panic!("encode cbor"));
+        let signed_cbor =
+            wasm::sign_cbor_vc_with_algorithm(&unsigned_cbor, "ML-DSA-44", &kp.signing_key())
+                .unwrap_or_else(|_| panic!("sign cbor w/ algorithm"));
+        assert!(wasm::verify_cbor_vc_auto(&signed_cbor, &kp.verifying_key())
+            .unwrap_or_else(|_| panic!("verify_cbor_vc_auto errored")));
+
+        let unsigned_pb = wasm::encode_unsigned_vc_to_protobuf(sample_credential_js())
+            .unwrap_or_else(|_| panic!("encode protobuf"));
+        let signed_pb =
+            wasm::sign_protobuf_vc_with_algorithm(&unsigned_pb, "ML-DSA-44", &kp.signing_key())
+                .unwrap_or_else(|_| panic!("sign protobuf w/ algorithm"));
+        assert!(
+            wasm::verify_protobuf_vc_auto(&signed_pb, &kp.verifying_key())
+                .unwrap_or_else(|_| panic!("verify_protobuf_vc_auto errored"))
+        );
     }
 }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -3,7 +3,7 @@ mod wasm_tests {
     use chrono::{DateTime, Duration, Utc};
     use url::Url;
     use verifiable_credential_toolkit::{
-        SchemaSource, SigningKey, UnsignedVerifiableCredential, VerifiableCredential,
+        Algorithm, SchemaSource, SigningKey, UnsignedVerifiableCredential, VerifiableCredential,
         VerifiablePresentation, VerifyingKey,
     };
     use wasm_bindgen_test::*;
@@ -52,7 +52,7 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::from_bytes(include_bytes!("test_data/keys/key.priv"))
+        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
             .expect("Invalid private key");
 
         let signed_vc = vc.sign(&private_key).unwrap();
@@ -73,7 +73,7 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::from_bytes(include_bytes!("test_data/keys/key.priv"))
+        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
             .expect("Invalid private key");
 
         let signed_vc = vc.sign(&private_key).expect("Failed to sign VC");
@@ -90,7 +90,7 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::from_bytes(include_bytes!("test_data/keys/key.priv"))
+        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
             .expect("Invalid private key");
 
         let schema_str = include_str!("test_data/schemas/schema.json");
@@ -112,7 +112,7 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::from_bytes(include_bytes!("test_data/keys/key.priv"))
+        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
             .expect("Invalid private key");
 
         let schema_str = include_str!("test_data/schemas/schema_fail.json");
@@ -128,7 +128,7 @@ mod wasm_tests {
 
     #[wasm_bindgen_test]
     fn signed_to_unsigned() {
-        let private_key = SigningKey::from_bytes(include_bytes!("test_data/keys/key.priv"))
+        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
             .expect("Invalid private key");
 
         let vc: VerifiableCredential = serde_json::from_str::<UnsignedVerifiableCredential>(
@@ -160,7 +160,7 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::from_bytes(include_bytes!("test_data/keys/key.priv"))
+        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
             .expect("Invalid private key");
 
         let mut signed_vc = vc.sign(&private_key).unwrap();
@@ -191,7 +191,7 @@ mod wasm_tests {
         ))
         .expect("Failed to deserialize JSON");
 
-        let private_key = SigningKey::from_bytes(include_bytes!("test_data/keys/key.priv"))
+        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
             .expect("Invalid private key");
 
         let mut signed_vc = vc.sign(&private_key).unwrap();
@@ -235,7 +235,7 @@ mod wasm_tests {
 
     #[wasm_bindgen_test]
     fn verify_signed_verifiable_credential() {
-        let private_key = SigningKey::from_bytes(include_bytes!("test_data/keys/key.priv"))
+        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
             .expect("Invalid private key");
 
         let vc: VerifiableCredential = serde_json::from_str::<UnsignedVerifiableCredential>(
@@ -245,7 +245,7 @@ mod wasm_tests {
         .sign(&private_key)
         .expect("Failed to sign VC");
 
-        let public_key = VerifyingKey::from_bytes(include_bytes!("test_data/keys/key.pub"))
+        let public_key = VerifyingKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.pub"))
             .expect("Invalid public key");
         let verify_result = vc.verify(&public_key);
 
@@ -258,7 +258,7 @@ mod wasm_tests {
 
     #[wasm_bindgen_test]
     fn verify_denies_modified_verifiable_credential() {
-        let private_key = SigningKey::from_bytes(include_bytes!("test_data/keys/key.priv"))
+        let private_key = SigningKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.priv"))
             .expect("Invalid private key");
 
         let vc: VerifiableCredential = serde_json::from_str::<UnsignedVerifiableCredential>(
@@ -275,7 +275,7 @@ mod wasm_tests {
         let edited_vc: VerifiableCredential =
             serde_json::from_str(&vc_serialized).expect("Failed to deserialize JSON");
 
-        let public_key = VerifyingKey::from_bytes(include_bytes!("test_data/keys/key.pub"))
+        let public_key = VerifyingKey::new(Algorithm::Ed25519, include_bytes!("test_data/keys/key.pub"))
             .expect("Invalid public key");
 
         let verify_result = edited_vc.verify(&public_key);
@@ -287,7 +287,7 @@ mod wasm_tests {
     /// sign, and verify for every parameter set, executed in the wasm test runner.
     #[wasm_bindgen_test]
     fn mldsa_sign_verify_on_wasm() {
-        use verifiable_credential_toolkit::{generate_keypair_bytes, Algorithm};
+        use verifiable_credential_toolkit::generate_keypair_bytes;
 
         let unsigned: UnsignedVerifiableCredential = serde_json::from_value(serde_json::json!({
             "@context": ["https://www.w3.org/ns/credentials/v2"],

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -282,4 +282,30 @@ mod wasm_tests {
 
         assert!(verify_result.is_err());
     }
+
+    /// ML-DSA must work at *runtime* on wasm, not just compile: generate a key pair,
+    /// sign, and verify for every parameter set, executed in the wasm test runner.
+    #[wasm_bindgen_test]
+    fn mldsa_sign_verify_on_wasm() {
+        use verifiable_credential_toolkit::{generate_keypair_bytes, Algorithm};
+
+        let unsigned: UnsignedVerifiableCredential = serde_json::from_value(serde_json::json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential"],
+            "issuer": "https://example.com/issuer",
+            "credentialSubject": { "id": "did:example:subject", "n": 42 }
+        }))
+        .expect("Failed to deserialize JSON");
+
+        for algorithm in [Algorithm::MlDsa44, Algorithm::MlDsa65, Algorithm::MlDsa87] {
+            let (private_key, public_key) = generate_keypair_bytes(algorithm);
+            let signed = unsigned
+                .clone()
+                .sign_with_algorithm(algorithm, &private_key)
+                .expect("ML-DSA signing should work on wasm");
+            signed
+                .verify_auto(&public_key)
+                .expect("ML-DSA verification should work on wasm");
+        }
+    }
 }

--- a/verifiable_credential_toolkit.d.ts
+++ b/verifiable_credential_toolkit.d.ts
@@ -176,5 +176,27 @@ export function verify_protobuf_vc(
   public_key: VerifyingKey
 ): boolean;
 
+// Multi-algorithm CBOR / Protobuf: sign with any supported cryptosuite (Ed25519 or
+// ML-DSA-44/65/87) and verify by reading the algorithm from the proof's cryptosuite.
+// Signatures are interoperable across JSON, CBOR, and Protobuf.
+export function sign_cbor_vc_with_algorithm(
+  unsigned_vc_cbor: Uint8Array,
+  algorithm: AlgorithmLabel,
+  private_key: Uint8Array
+): Uint8Array;
+export function verify_cbor_vc_auto(
+  signed_vc_cbor: Uint8Array,
+  public_key: Uint8Array
+): boolean;
+export function sign_protobuf_vc_with_algorithm(
+  unsigned_vc_protobuf: Uint8Array,
+  algorithm: AlgorithmLabel,
+  private_key: Uint8Array
+): Uint8Array;
+export function verify_protobuf_vc_auto(
+  signed_vc_protobuf: Uint8Array,
+  public_key: Uint8Array
+): boolean;
+
 export function normalize_object(input: any): any;
 export function normalize_and_stringify(input: any): string;

--- a/verifiable_credential_toolkit.d.ts
+++ b/verifiable_credential_toolkit.d.ts
@@ -89,6 +89,47 @@ export function verify_with_schema_check(
   schema: any
 ): boolean;
 
+/**
+ * A signature algorithm label accepted by the multi-algorithm functions.
+ * Case- and separator-insensitive (e.g. "ML-DSA-65", "mldsa65" both work).
+ */
+export type AlgorithmLabel =
+  | "Ed25519"
+  | "ML-DSA-44"
+  | "ML-DSA-65"
+  | "ML-DSA-87";
+
+/** Generate a key pair for the given algorithm, returning raw key bytes. */
+export function generate_keypair_for(algorithm: AlgorithmLabel): KeyPair;
+
+/**
+ * Sign with the given algorithm and a raw private key of the matching length
+ * (Ed25519: 32 bytes; ML-DSA: the FIPS 204 expanded signing key — 2560 / 4032 / 4896
+ * bytes for ML-DSA-44 / 65 / 87).
+ */
+export function sign_with_algorithm(
+  unsigned_vc: UnsignedVerifiableCredential,
+  algorithm: AlgorithmLabel,
+  private_key: Uint8Array
+): VerifiableCredential;
+
+/** Verify with an explicit algorithm and a raw public key. False on any failure. */
+export function verify_with_algorithm(
+  signed_vc: VerifiableCredential,
+  algorithm: AlgorithmLabel,
+  public_key: Uint8Array
+): boolean;
+
+/**
+ * Verify by reading the algorithm from the proof's `cryptosuite` and dispatching
+ * automatically — the caller supplies only the raw public key bytes. False on any
+ * failure (including an unsupported cryptosuite).
+ */
+export function verify_auto(
+  signed_vc: VerifiableCredential,
+  public_key: Uint8Array
+): boolean;
+
 // CBOR bindings: encode/decode credentials to and from CBOR bytes, and sign/verify
 // CBOR-encoded credential bytes.
 export function encode_unsigned_vc_to_cbor(

--- a/wasm_js_example_usage/index.ts
+++ b/wasm_js_example_usage/index.ts
@@ -26,6 +26,14 @@ import init, {
   decode_signed_vc_from_protobuf,
   sign_protobuf_vc,
   verify_protobuf_vc,
+  generate_keypair_for,
+  sign_with_algorithm,
+  verify_with_algorithm,
+  verify_auto,
+  sign_cbor_vc_with_algorithm,
+  verify_cbor_vc_auto,
+  sign_protobuf_vc_with_algorithm,
+  verify_protobuf_vc_auto,
 } from "./pkg/verifiable_credential_toolkit.js";
 // Data-model types from the hand-maintained root declaration file (erased at runtime).
 import type {
@@ -193,6 +201,37 @@ async function run(): Promise<void> {
     pbRejected = true;
   }
   check("tampered Protobuf is rejected", pbRejected);
+
+  // ── 10. Post-quantum ML-DSA (multi-algorithm API) ─────────────────────────
+  // The same flows, signed with post-quantum ML-DSA-65 instead of Ed25519.
+  // `generate_keypair_for` returns raw FIPS-204 key bytes and `verify_auto` reads the
+  // algorithm from the proof, so a verifier only needs the public key. ML-DSA runs in
+  // the browser thanks to the 8 MB wasm stack and the getrandom wasm_js backend.
+  section("10. Post-quantum ML-DSA");
+  const ALG = "ML-DSA-65";
+  const pqKeys = generate_keypair_for(ALG);
+  const pqSk = pqKeys.signing_key();
+  const pqPk = pqKeys.verifying_key();
+  check("ML-DSA-65 private key is 4032 bytes", pqSk.length === 4032);
+  check("ML-DSA-65 public key is 1952 bytes", pqPk.length === 1952);
+
+  const pqSigned: VerifiableCredential = sign_with_algorithm(baseVC, ALG, pqSk);
+  check("ML-DSA cryptosuite recorded", pqSigned.proof?.cryptosuite === "mldsa65-jcs-2025");
+  check("verify_with_algorithm succeeds", verify_with_algorithm(pqSigned, ALG, pqPk) === true);
+  check("verify_auto succeeds", verify_auto(pqSigned, pqPk) === true);
+
+  const pqTampered: VerifiableCredential = JSON.parse(JSON.stringify(pqSigned));
+  pqTampered.credentialSubject.name = "TAMPERED NAME";
+  check("tampered ML-DSA credential is rejected", verify_auto(pqTampered, pqPk) === false);
+
+  const pqCbor = sign_cbor_vc_with_algorithm(encode_unsigned_vc_to_cbor(baseVC), ALG, pqSk);
+  check("ML-DSA over CBOR verifies", verify_cbor_vc_auto(pqCbor, pqPk) === true);
+  const pqPbBytes = sign_protobuf_vc_with_algorithm(
+    encode_unsigned_vc_to_protobuf(baseVC),
+    ALG,
+    pqSk,
+  );
+  check("ML-DSA over Protobuf verifies", verify_protobuf_vc_auto(pqPbBytes, pqPk) === true);
 }
 
 run().catch((err) => {

--- a/wasm_nodejs_example_usage/index.ts
+++ b/wasm_nodejs_example_usage/index.ts
@@ -28,6 +28,14 @@ import {
   decode_signed_vc_from_protobuf,
   sign_protobuf_vc,
   verify_protobuf_vc,
+  generate_keypair_for,
+  sign_with_algorithm,
+  verify_with_algorithm,
+  verify_auto,
+  sign_cbor_vc_with_algorithm,
+  verify_cbor_vc_auto,
+  sign_protobuf_vc_with_algorithm,
+  verify_protobuf_vc_auto,
 } from "./pkg/verifiable_credential_toolkit.js";
 // Data-model types come from the hand-maintained root declaration file; these
 // imports are erased at runtime (Node strips them).
@@ -220,6 +228,44 @@ try {
   pbRejected = true;
 }
 check("tampered Protobuf is rejected", pbRejected);
+
+// ── 10. Post-quantum ML-DSA (multi-algorithm API) ─────────────────────────
+// The same JSON / CBOR / Protobuf round-trips, but signed with ML-DSA-65 instead
+// of Ed25519. `generate_keypair_for` returns raw FIPS-204 key bytes; `verify_auto`
+// reads the algorithm from the proof's cryptosuite, so the verifier only needs the
+// public key. Signatures are interoperable across all three formats.
+section("10. Post-quantum ML-DSA");
+const ALG = "ML-DSA-65";
+const pqKeys = generate_keypair_for(ALG);
+const pqSk = pqKeys.signing_key();
+const pqPk = pqKeys.verifying_key();
+check("ML-DSA-65 private key is 4032 bytes", pqSk.length === 4032);
+check("ML-DSA-65 public key is 1952 bytes", pqPk.length === 1952);
+
+const pqSigned: VerifiableCredential = sign_with_algorithm(baseVC, ALG, pqSk);
+check(
+  "ML-DSA cryptosuite is recorded in the proof",
+  pqSigned.proof?.cryptosuite === "mldsa65-jcs-2025",
+);
+check(
+  "verify_with_algorithm succeeds",
+  verify_with_algorithm(pqSigned, ALG, pqPk) === true,
+);
+check("verify_auto (reads the cryptosuite) succeeds", verify_auto(pqSigned, pqPk) === true);
+
+const pqTampered: VerifiableCredential = JSON.parse(JSON.stringify(pqSigned));
+pqTampered.credentialSubject.name = "TAMPERED NAME";
+check("tampered ML-DSA credential is rejected", verify_auto(pqTampered, pqPk) === false);
+check("a wrong ML-DSA key is rejected", verify_auto(pqSigned, generate_keypair_for(ALG).verifying_key()) === false);
+
+// ML-DSA over CBOR and Protobuf, signed once via JSON and re-verified after transport.
+const pqCbor = sign_cbor_vc_with_algorithm(encode_unsigned_vc_to_cbor(baseVC), ALG, pqSk);
+check("ML-DSA over CBOR verifies (verify_cbor_vc_auto)", verify_cbor_vc_auto(pqCbor, pqPk) === true);
+const pqPb = sign_protobuf_vc_with_algorithm(encode_unsigned_vc_to_protobuf(baseVC), ALG, pqSk);
+check(
+  "ML-DSA over Protobuf verifies (verify_protobuf_vc_auto)",
+  verify_protobuf_vc_auto(pqPb, pqPk) === true,
+);
 
 // ── Summary ───────────────────────────────────────────────────────────────
 section("Summary");


### PR DESCRIPTION
# Add ML-DSA (post-quantum) support and a unified multi-algorithm API

Branch `47-issues-to-be-tackled-for-adding-ml-dsa-support` · bumps **0.6.0 → 0.7.0**.

Builds on the existing 0.6.0 (W3C VC data model, JCS-canonical signing,
`DataIntegrityProof`, CBOR/Protobuf bindings — all Ed25519-only) and adds
post-quantum ML-DSA behind one algorithm-agnostic API, reworks the key model and
proof encoding, and substantially expands tests, examples, and docs.

## Highlights

- **Post-quantum signatures.** ML-DSA (FIPS 204) in all three parameter sets — ML-DSA-44/65/87 — alongside Ed25519.
- **One API for every algorithm.** `Algorithm` enum + a `SignatureScheme` seam; the same `sign` / `verify` works for Ed25519 or any ML-DSA set. ML-DSA is not a separate API.
- **Unified, typed keys.** `SigningKey` / `VerifyingKey` carry their `Algorithm` and are length-checked at construction; a raw-byte path exists for HSM / wasm / cross-language interop.
- **All algorithms over all formats.** JSON, CBOR, and Protobuf, with sign-once/verify-anywhere cross-format interop (the signature is over the JCS canonical form).
- **Multibase proof values.** `proofValue` is now multibase (base58btc) per W3C Data Integrity, replacing base64.
- **WASM parity.** ML-DSA, the multi-algorithm functions, and the CBOR/Protobuf helpers are all exposed to JS, and exercised by wasm tests.

## What's new / changed

### Algorithms & crypto
- `Algorithm` enum: `Ed25519`, `MlDsa44`, `MlDsa65`, `MlDsa87`, each with a `cryptosuite()` (`eddsa-jcs-2022`, `mldsa{44,65,87}-jcs-2025`) and `from_cryptosuite()`.
- New `src/crypto/` module: a private `SignatureScheme` trait with per-algorithm implementations in `ed25519.rs` and `mldsa.rs`, dispatched from `mod.rs`. This is the single seam for swapping in a FIPS-validated / HSM backend later.
- ML-DSA via the `ml-dsa` crate: **hedged** (FIPS 204 randomized) signing, no-panic key loading (malformed caller-supplied keys become a typed error via `catch_unwind`), FIPS 204 key/signature sizes.

### Key model
- `SigningKey` / `VerifyingKey` are now `{ algorithm, bytes }`, constructed with `::new(Algorithm, &[u8])` (length-checked) and read with `.as_bytes()` / `.algorithm()`.
- `generate_keypair(Algorithm) → KeyPair`; `generate_keypair_bytes(Algorithm)` for raw bytes.
- The old Ed25519-only `SigningKey`/`VerifyingKey` newtypes and the separate ML-DSA key types are gone — one model for all algorithms.

### Signing / verifying
- `sign(&SigningKey)` and `verify(&VerifyingKey)` read the algorithm from the key; `verify` also checks the proof's `cryptosuite` matches the key and enforces the validity period.
- Raw-byte path: `sign_with_algorithm`, `verify_with_algorithm`, `verify_auto` (dispatches on the proof's cryptosuite).
- External-signer path: `signing_payload()` → sign externally → `Proof::new_data_integrity(cryptosuite, proofValue)` + `VerifiableCredential::from_parts`.
- A proof with no/unknown `cryptosuite` is now rejected (`MissingCryptosuite` / `UnsupportedCryptosuite`) rather than assumed Ed25519.

### Wire formats
- `CredentialCodec` reshaped: implementors supply four encode/decode conversions, and `sign` / `verify` / `verify_auto` are provided as algorithm-aware default methods. Both `Cbor` and `Protobuf` work with every algorithm.

### WASM / JavaScript
- New exports: `generate_keypair_for(label)`, `sign_with_algorithm`, `verify_with_algorithm`, `verify_auto`, and the `_with_algorithm` / `_auto` variants for CBOR and Protobuf.
- `.cargo/config.toml` sets the wasm stack size (ML-DSA expands large matrices) and the `getrandom` wasm backend so hedged signing runs in the browser/Node.
- `.d.ts` updated.

### Errors
- `VcError` reworked: `MissingCryptosuite`, `UnsupportedCryptosuite(String)`, `KeyDecode(String)`, string-carrying `InvalidPublicKey` / `MalformedSignature`, multibase `ProofDecode`; `SignatureVerificationFailed` is a unit variant.

## Breaking changes

- **`proofValue` encoding changed** (base64 → multibase base58btc) and `Proof::new_eddsa_jcs_2022` → `Proof::new_data_integrity`. **Credentials signed by 0.6.x must be re-signed** — this affects Ed25519 too, not just the new algorithms.
- **Key API:** `SigningKey::from_bytes` / `to_bytes` → `SigningKey::new(Algorithm, …)` / `as_bytes`; keys now carry an `Algorithm`; `generate_keypair()` now takes an `Algorithm`.
- **`verify` now rejects a missing or unknown `cryptosuite`.**
- **`VcError` variants changed** (removed the Ed25519-specific length variants; `SignatureVerificationFailed` is now a unit variant).

## Dependencies

- **Added:** `ml-dsa` 0.1.1, `multibase` 0.9.2, `getrandom` 0.4 (`getrandom_v04`, `sys_rng` + `wasm_js`), `getrandom` 0.2 (`js`, wasm only).
- **Removed:** `base64` (replaced by multibase), `rand` (keygen now via `getrandom`).
- **Changed:** `ed25519-dalek` drops the `rand_core` feature; `reqwest` de-duplicated (was declared twice).

> **Not FIPS-validated.** ML-DSA uses the pure-Rust `ml-dsa` crate, which is not a FIPS 140-3 validated module and is not guaranteed constant-time. Suitable for pilots; a hard FIPS requirement needs a validated backend (AWS-LC-FIPS / HSM) dropped in behind `SignatureScheme`. The `mldsa*-jcs-2025` cryptosuite IDs are a provisional bilateral convention pending the W3C `vc-di-mldsa` spec. See `KNOWN_ISSUES.md`.

## Tests & CI

- All-algorithms sign/verify loops over the core, CBOR, and Protobuf paths; FIPS 204 key/signature-size pins; hedged-nondeterminism; cross-algorithm and mismatched-param-set rejection; missing/unknown cryptosuite; number-fidelity and cross-format interop; a JCS-canonicalization regression guard; and wasm tests for the JS ABI (sign/verify, multi-algorithm, schema check, CBOR/Protobuf).
- CI (`.github/workflows/rust.yml`) runs the examples and the wasm build.

## Docs

- `README.md` rewritten around the unified API, with each flow showing its primary path plus commented-out alternatives; new `examples/post_quantum.rs`.
- A static docs site under `docs/`, plus `EXTENDING.md` (maintainer guide for adding algorithms/formats) and `KNOWN_ISSUES.md`.


